### PR TITLE
Fix: 서비스레이어 메소드 수정

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/AdoptNoticeStatusUpdateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/AdoptNoticeStatusUpdateRequestDto.java
@@ -1,0 +1,8 @@
+package meet.myo.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class AdoptNoticeStatusUpdateRequestDto {
+    private String status;
+}

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/EmailDuplicationCheckRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/EmailDuplicationCheckRequestDto.java
@@ -1,0 +1,4 @@
+package meet.myo.dto.request;
+
+public class EmailDuplicationCheckRequestDto {
+}

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/NickNameDuplicationCheckRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/NickNameDuplicationCheckRequestDto.java
@@ -1,0 +1,4 @@
+package meet.myo.dto.request;
+
+public class NickNameDuplicationCheckRequestDto {
+}

--- a/MyohanMeeting/src/main/java/meet/myo/service/AdoptApplicationService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/AdoptApplicationService.java
@@ -6,7 +6,6 @@ import meet.myo.dto.request.AdoptApplicationUpdateRequestDto;
 import meet.myo.dto.response.AdoptApplicationResponseDto;
 import meet.myo.repository.AdoptNoticeRepoImpl;
 import meet.myo.repository.AdoptNoticeRepository;
-import meet.myo.search.AdoptApplicationSearch;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +24,7 @@ public class AdoptApplicationService {
      * 특정 공고에 달린 분양신청 목록 조회
      */
     @Transactional(readOnly = true)
-    public List<AdoptApplicationResponseDto> getAdoptApplicationList(Pageable pageable, AdoptApplicationSearch search) {
+    public List<AdoptApplicationResponseDto> getAdoptApplicationListByNotice(Long memberId, Long noticeId, Pageable pageable, String ordered) {
         return List.of(AdoptApplicationResponseDto.fromEntity());
     }
 
@@ -33,7 +32,7 @@ public class AdoptApplicationService {
      * 내가 작성한 분양신청 목록 조회
      */
     @Transactional(readOnly = true)
-    public List<AdoptApplicationResponseDto> getMyAdoptApplicationList(Pageable pageable, Long memberId) {
+    public List<AdoptApplicationResponseDto> getMyAdoptApplicationList(Long memberId, Pageable pageable, String ordered) {
         return List.of(AdoptApplicationResponseDto.fromEntity());
     }
 
@@ -41,28 +40,28 @@ public class AdoptApplicationService {
      * 단일 조회
      */
     @Transactional(readOnly = true)
-    public AdoptApplicationResponseDto getAdoptApplication(Long id) {
+    public AdoptApplicationResponseDto getAdoptApplication(Long applicationId) {
         return AdoptApplicationResponseDto.fromEntity();
     }
 
     /**
      * 작성
      */
-    public Long createAdoptApplication(AdoptApplicationCreateRequestDto dto) {
+    public Long createAdoptApplication(Long memberId, AdoptApplicationCreateRequestDto dto) {
         return 1L;
     }
 
     /**
      * 수정
      */
-    public AdoptApplicationResponseDto updateAdoptApplication(AdoptApplicationUpdateRequestDto dto) {
+    public AdoptApplicationResponseDto updateAdoptApplication(Long memberId, Long applicationId, AdoptApplicationUpdateRequestDto dto) {
         return AdoptApplicationResponseDto.fromEntity();
     }
 
     /**
      * 삭제
      */
-    public Long deleteAdoptApplication(Long id) {
+    public Long deleteAdoptApplication(Long memberId, Long applicationId) {
         return 1L;
     }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/service/AdoptNoticeService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/AdoptNoticeService.java
@@ -2,6 +2,7 @@ package meet.myo.service;
 
 import lombok.RequiredArgsConstructor;
 import meet.myo.dto.request.AdoptNoticeCreateRequestDto;
+import meet.myo.dto.request.AdoptNoticeStatusUpdateRequestDto;
 import meet.myo.dto.response.AdoptNoticeResponseDto;
 import meet.myo.dto.request.AdoptNoticeUpdateRequestDto;
 import meet.myo.repository.AdoptNoticeRepoImpl;
@@ -31,10 +32,10 @@ public class AdoptNoticeService {
     }
 
     /**
-     * 내가 쓴 공고목록 조회
+     * 특정 회원의 공고목록 전체 조회
      */
     @Transactional(readOnly = true)
-    public List<AdoptNoticeResponseDto> getMyAdoptNoticeList(Pageable pageable, Long memberId) {
+    public List<AdoptNoticeResponseDto> getMyAdoptNoticeList(Long memberId, Pageable pageable, String ordered) {
         return List.of(AdoptNoticeResponseDto.fromEntity());
     }
 
@@ -42,29 +43,35 @@ public class AdoptNoticeService {
      * 단일 조회
      */
     @Transactional(readOnly = true)
-    public AdoptNoticeResponseDto getAdoptNotice(Long id) {
+    public AdoptNoticeResponseDto getAdoptNotice(Long noticeId) {
         return AdoptNoticeResponseDto.fromEntity();
     }
 
     /**
      * 작성
      */
-    public Long createAdoptNotice(AdoptNoticeCreateRequestDto dto) {
+    public Long createAdoptNotice(Long memberId, AdoptNoticeCreateRequestDto dto) {
         return 1L;
+    }
+
+    /**
+     * 상태 수정
+     */
+    public AdoptNoticeResponseDto updateAdoptNoticeStatus(Long memberId, Long noticeId, AdoptNoticeStatusUpdateRequestDto dto) {
+        return AdoptNoticeResponseDto.fromEntity();
     }
 
     /**
      * 수정
      */
-    //TODO: 글 상태만 변경하는 엔드포인트를 따로 만들어야 할까요?
-    public AdoptNoticeResponseDto updateAdoptNotice(AdoptNoticeUpdateRequestDto dto) {
+    public AdoptNoticeResponseDto updateAdoptNotice(Long memberId, Long noticeId, AdoptNoticeUpdateRequestDto dto) {
         return AdoptNoticeResponseDto.fromEntity();
     }
 
     /**
      * 삭제
      */
-    public Long deleteAdoptNotice(Long id) {
+    public Long deleteAdoptNotice(Long memberId, Long noticeId) {
         return 1L;
     }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
@@ -32,35 +32,49 @@ public class MemberService {
     /**
      * 회원가입(SNS)
      */
-    public Long directOauth(MemberOauthCreateRequestDto dto) {
+    public Long oauthJoin(MemberOauthCreateRequestDto dto) {
         return 1L;
+    }
+
+    /**
+     * 이메일 중복체크
+     */
+    public void emailDuplicationCheck(EmailDuplicationCheckRequestDto dto) {
+
+    }
+
+    /**
+     * 닉네임 중복체크
+     */
+    public void nickNameDuplicationCheck(NickNameDuplicationCheckRequestDto dto) {
+
     }
 
     /**
      * 이메일 인증용 메일발송 및 UUID 저장
      */
-    public void sendCertificationEmail() { // TODO: 별 리턴내용이 없긴한데 그래도 void는 아닌거같죠...?
+    public void sendCertificationEmail(Long memberId) { // TODO: 리턴항목 생각
 
     }
 
     /**
      * 이메일 인증 UUID 비교
      */
-    public void verifyCertificationEmail(CertifyEmailRequestDto dto) {
+    public void verifyCertificationEmail(Long memberId, CertifyEmailRequestDto dto) {
 
     }
 
     /**
      * 이메일 수정
      */
-    public EmailUpdateResponseDto updateEmail(EmailUpdateRequestDto dto) {
+    public EmailUpdateResponseDto updateEmail(Long memberId, EmailUpdateRequestDto dto) {
         return EmailUpdateResponseDto.fromEntity();
     }
 
     /**
      * Oauth 수정
      */
-    public OauthUpdateResponseDto updateOauth(OauthUpdateRequestDto dto) {
+    public OauthUpdateResponseDto updateOauth(Long memberId, OauthUpdateRequestDto dto) {
         return OauthUpdateResponseDto.fromEntity();
     }
 
@@ -76,15 +90,15 @@ public class MemberService {
     /**
      * 비밀번호 수정
      */
-    public PasswordUpdateResponseDto updatePassword(PasswordUpdateRequestDto dto) {
-        return PasswordUpdateResponseDto.fromEntity();
+    public void updatePassword(Long memberId, PasswordUpdateRequestDto dto) {
+        //TODO: 리턴값 생각
     }
 
 
     /**
      * 개인정보 수정
      */
-    public MemberUpdateResponseDto updateMember(MemberUpdateRequestDto dto) {
+    public MemberUpdateResponseDto updateMember(Long memberId, MemberUpdateRequestDto dto) {
         return MemberUpdateResponseDto.fromEntity();
     }
 
@@ -92,7 +106,7 @@ public class MemberService {
     /**
      * 탈퇴
      */
-    public Long resign(Long id) {
+    public Long resign(Long memberId) {
         return 1L;
     }
 

--- a/MyohanMeeting/src/main/java/meet/myo/service/UploadService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/UploadService.java
@@ -20,21 +20,21 @@ public class UploadService {
      * 파일상세 엔티티 조회
      */
     @Transactional(readOnly = true)
-    public UploadResponseDto getFileDetail(Long id) {
+    public UploadResponseDto getFileDetail(Long memberId, Long uploadId) {
         return UploadResponseDto.fromEntity();
     }
 
     /**
      * 파일 업로드 처리
      */
-    public Long uploadFile(List<MultipartFile> files) {
-        return 1L;
+    public List<Long> uploadFiles(Long memberId, List<MultipartFile> files) {
+        return List.of(1L);
     }
 
     /**
      * 파일 삭제 처리
      */
-    public List<Long> deleteFile(List<Long> idList) {
+    public List<Long> deleteFiles(Long memberId, List<Long> uploadIdList) {
         return List.of(1L);
     }
 


### PR DESCRIPTION
- 누락된 필드(memberId나 정렬 플래그 등) 추가 (#22 이슈 참조)
- 변수명 명확하게 수정
- 입양공고 상태변경 메소드 분리
- 이메일, 닉네임 중복확인 메소드 추가