### PR TITLE
Hot fix/ 오타 수정 등

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/domain/EmailCertification.java
+++ b/MyohanMeeting/src/main/java/meet/myo/domain/EmailCertification.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class EmailCertification extends BaseAuditingListner {
+public class EmailCertification extends BaseAuditingListener {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +23,6 @@ public class EmailCertification extends BaseAuditingListner {
     private Member member;
 
     private String UUID;
-
 
     private EmailCertification(Member member) {
         this.member = member;
@@ -39,7 +38,7 @@ public class EmailCertification extends BaseAuditingListner {
     }
 
     private boolean isExpired() {
-        return Duration.between(super.getCreateAt(), LocalDateTime.now())
+        return Duration.between(super.getCreatedAt(), LocalDateTime.now())
                 .compareTo(Duration.ofSeconds(3000))  // TODO: 임의로 만료시간 5분 설정
                 >= 0;
     }

--- a/MyohanMeeting/src/main/java/meet/myo/domain/Member.java
+++ b/MyohanMeeting/src/main/java/meet/myo/domain/Member.java
@@ -71,6 +71,7 @@ public class Member extends BaseAuditingListener {
             this.certified = Certified.CERTIFIED;
         } else {
             // TODO: 이미 인증된 회원임을 알리는 로직이 필요할까요?
+            // conflict
         }
     }
 }


### PR DESCRIPTION
- EmailCertification 엔티티의 오타 수정
- Member 엔티티의 74 line에서 406 Conflict를 반환해야 하므로 주석 추가