### PR TITLE
Feat/문서화 작업

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptApplicationController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptApplicationController.java
@@ -3,6 +3,9 @@ package meet.myo.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -124,7 +127,17 @@ public class AdoptApplicationController {
      * 분양신청 작성
      */
     @Operation(summary = "분양신청 작성", description = "분양 신청서를 작성합니다.", operationId = "createApplication")
-    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseSignin
+    @ApiResponse(responseCode = "200", description = "작성 성공", content = @Content(
+            schema = @Schema(implementation = CommonResponseDto.class), examples = { @ExampleObject(value = """
+{
+  "status": "200 OK",
+  "timestamp": "2023-06-10T09:19:08.550Z",
+  "message": "SUCCESS",
+  "data": {
+    "applicationId" : 1
+  }
+}
+""")})) @ApiResponseCommon @ApiResponseResource @ApiResponseSignin
     @PostMapping("")
     public CommonResponseDto<Map<String, Long>> createApplicationV1(
             @Validated @RequestBody final AdoptApplicationCreateRequestDto dto
@@ -157,7 +170,17 @@ public class AdoptApplicationController {
      * 분양신청 삭제
      */
     @Operation(summary = "분양신청 삭제", description = "분양 신청서를 삭제합니다.", operationId = "deleteApplication")
-    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
+    @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content(
+            schema = @Schema(implementation = CommonResponseDto.class), examples = { @ExampleObject(value = """
+{
+  "status": "200 OK",
+  "timestamp": "2023-06-10T09:19:08.550Z",
+  "message": "SUCCESS",
+  "data": {
+    "applicationId" : 1
+  }
+}
+""")})) @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @DeleteMapping("/{applicationId}")
     public CommonResponseDto<Map<String, Long>> deleteApplicationV1(
             @Parameter(name = "applicationId", description = "삭제하고자 하는 분양신청의 id입니다.")

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeCommentController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeCommentController.java
@@ -2,6 +2,9 @@ package meet.myo.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,7 +51,17 @@ public class AdoptNoticeCommentController {
      * 분양공고 댓글 작성
      */
     @Operation(summary = "분양공고 댓글 작성", description = "분양공고 댓글을 작성합니다.", operationId = "createNoticeComment")
-    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseSignin
+    @ApiResponse(responseCode = "200", description = "작성 성공", content = @Content(
+            schema = @Schema(implementation = CommonResponseDto.class), examples = { @ExampleObject(value = """
+{
+  "status": "200 OK",
+  "timestamp": "2023-06-10T09:19:08.550Z",
+  "message": "SUCCESS",
+  "data": {
+    "noticeCommentId" : 1
+  }
+}
+""")})) @ApiResponseCommon @ApiResponseResource @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
     @PostMapping("/comments")
     public CommonResponseDto<Map<String, Long>> createNoticeCommentV1(
@@ -83,7 +96,17 @@ public class AdoptNoticeCommentController {
      * 분양공고 댓글 삭제
      */
     @Operation(summary = "분양공고 댓글 삭제", description = "분양공고 댓글을 삭제합니다.", operationId = "deleteNoticeComment")
-    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
+    @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content(
+            schema = @Schema(implementation = CommonResponseDto.class), examples = { @ExampleObject(value = """
+{
+  "status": "200 OK",
+  "timestamp": "2023-06-10T09:19:08.550Z",
+  "message": "SUCCESS",
+  "data": {
+    "noticeCommentId" : 1
+  }
+}
+""")})) @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @SecurityRequirement(name = "JWT")
     @DeleteMapping("/comments/{noticeCommentId}")
     public CommonResponseDto<Map<String, Long>> deleteNoticeCommentV1(

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
@@ -3,6 +3,8 @@ package meet.myo.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -187,7 +189,17 @@ public class AdoptNoticeController {
      * 분양공고 작성
      */
     @Operation(summary = "분양공고 작성", description = "분양공고를 작성합니다.", operationId = "createNotice")
-    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
+    @ApiResponse(responseCode = "200", description = "작성 성공", content = @Content(
+            schema = @Schema(implementation = CommonResponseDto.class), examples = { @ExampleObject(value = """
+{
+  "status": "200 OK",
+  "timestamp": "2023-06-10T09:19:08.550Z",
+  "message": "SUCCESS",
+  "data": {
+    "noticeId" : 1
+  }
+}
+""")})) @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
     @PostMapping("")
     public CommonResponseDto<Map<String, Long>> createNoticeV1(@Validated @RequestBody final AdoptNoticeCreateRequestDto dto) {
@@ -239,7 +251,17 @@ public class AdoptNoticeController {
      * 분양공고 삭제
      */
     @Operation(summary = "분양공고 삭제", description = "분양공고를 삭제합니다.", operationId = "deleteNotice")
-    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
+    @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content(
+            schema = @Schema(implementation = CommonResponseDto.class), examples = { @ExampleObject(value = """
+{
+  "status": "200 OK",
+  "timestamp": "2023-06-10T09:19:08.550Z",
+  "message": "SUCCESS",
+  "data": {
+    "noticeId" : 1
+  }
+}
+""")})) @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @SecurityRequirement(name = "JWT")
     @DeleteMapping("/{noticeId}")
     public CommonResponseDto<Map<String, Long>> deleteNoticeV1(

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
@@ -15,6 +15,7 @@ import meet.myo.dto.request.adopt.AdoptNoticeStatusUpdateRequestDto;
 import meet.myo.dto.request.adopt.AdoptNoticeUpdateRequestDto;
 import meet.myo.dto.response.adopt.AdoptNoticeResponseDto;
 import meet.myo.dto.response.CommonResponseDto;
+import meet.myo.dto.response.adopt.AdoptNoticeSummaryResponseDto;
 import meet.myo.search.AdoptNoticeSearch;
 import meet.myo.service.AdoptNoticeService;
 import meet.myo.springdoc.annotations.*;
@@ -40,7 +41,7 @@ public class AdoptNoticeController {
     @Operation(summary = "분양공고 목록조회", description = "검색 조건에 따른 분양 공고 목록을 조회합니다.", operationId = "getNoticeList")
     @ApiResponse(responseCode = "200") @ApiResponseCommon
     @GetMapping("")
-    public CommonResponseDto<List<AdoptNoticeResponseDto>> getNoticeListV1(
+    public CommonResponseDto<List<AdoptNoticeSummaryResponseDto>> getNoticeListV1(
             /**
              * 페이징
              */
@@ -126,7 +127,7 @@ public class AdoptNoticeController {
                 .sort(sort)
                 .build();
 
-        return CommonResponseDto.<List<AdoptNoticeResponseDto>>builder()
+        return CommonResponseDto.<List<AdoptNoticeSummaryResponseDto>>builder()
                 .data(adoptNoticeService.getAdoptNoticeList(pageable, search))
                 .build();
     }
@@ -137,7 +138,7 @@ public class AdoptNoticeController {
     @Operation(summary = "내가 올린 분양공고 목록조회", description = "자신이 업로드한 분양 공고 목록을 조회합니다.", operationId = "getMyNoticeList")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @GetMapping("/my")
-    public CommonResponseDto<List<AdoptNoticeResponseDto>> getMyNoticeListV1(
+    public CommonResponseDto<List<AdoptNoticeSummaryResponseDto>> getMyNoticeListV1(
             /**
              * 페이징
              */
@@ -164,7 +165,7 @@ public class AdoptNoticeController {
     ) {
         Long memberId = 1L; // TODO: security
         Pageable pageable = PageRequest.of(page, size);
-        return CommonResponseDto.<List<AdoptNoticeResponseDto>>builder()
+        return CommonResponseDto.<List<AdoptNoticeSummaryResponseDto>>builder()
                 .data(adoptNoticeService.getMyAdoptNoticeList(memberId, pageable, sort))
                 .build();
     }

--- a/MyohanMeeting/src/main/java/meet/myo/controller/FavoriteController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/FavoriteController.java
@@ -3,6 +3,9 @@ package meet.myo.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -61,7 +64,17 @@ public class FavoriteController {
      */
     @Operation(summary = "최애친구 작성",
             description = "하트를 클릭해 최애친구를 생성합니다.", operationId = "createFavorite")
-    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseSignin
+    @ApiResponse(responseCode = "200", description = "작성 성공", content = @Content(
+            schema = @Schema(implementation = CommonResponseDto.class), examples = { @ExampleObject(value = """
+{
+  "status": "200 OK",
+  "timestamp": "2023-06-10T09:19:08.550Z",
+  "message": "SUCCESS",
+  "data": {
+    "favoriteId" : 1
+  }
+}
+""")})) @ApiResponseCommon @ApiResponseResource @ApiResponseSignin
     @PostMapping("")
     public CommonResponseDto<Map<String, Long>> createFavoriteV1(
             @Validated @RequestBody final CreateFavoriteRequestDto dto
@@ -77,7 +90,17 @@ public class FavoriteController {
      */
     @Operation(summary = "최애친구 삭제",
             description = "하트를 클릭해 최애친구를 삭제합니다.", operationId = "deleteFavorite")
-    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
+    @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content(
+            schema = @Schema(implementation = CommonResponseDto.class), examples = { @ExampleObject(value = """
+{
+  "status": "200 OK",
+  "timestamp": "2023-06-10T09:19:08.550Z",
+  "message": "SUCCESS",
+  "data": {
+    "favoriteId" : 1
+  }
+}
+""")})) @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @DeleteMapping("/{favoriteId}")
     public CommonResponseDto<Map<String, Long>> deleteFavoriteV1(
             @Parameter(name = "favoriteId", description = "삭제하고자 하는 최애친구의 id입니다.")

--- a/MyohanMeeting/src/main/java/meet/myo/controller/UploadController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/UploadController.java
@@ -2,6 +2,9 @@ package meet.myo.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,7 +41,7 @@ public class UploadController {
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @GetMapping("/{uploadId}")
     public CommonResponseDto<UploadResponseDto> getFileDetailV1(
-            @Parameter(name = "noticeId", description = "삭제하고자 하는 공고의 id입니다.")
+            @Parameter(name = "uploadId", description = "조회하고자 하는 파일의 id입니다.")
             @PathVariable(name = "uploadId") Long uploadId
     ) {
         Long memberId = 1L; //TODO: security
@@ -51,10 +54,20 @@ public class UploadController {
      * 파일 업로드
      */
     @Operation(summary = "파일 업로드", description = "파일을 배열로 업로드합니다.", operationId = "uploadFiles")
-    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
+    @ApiResponse(responseCode = "200", description = "업로드 성공", content = @Content(
+            schema = @Schema(implementation = CommonResponseDto.class), examples = { @ExampleObject(value = """
+{
+  "status": "200 OK",
+  "timestamp": "2023-06-10T09:19:08.550Z",
+  "message": "SUCCESS",
+  "data": {
+    "uploadIdList" : [1, 2, 3, 4]
+  }
+}
+""")})) @ApiResponseCommon @ApiResponseSignin
     @PostMapping("")
     public CommonResponseDto<Map<String, List<Long>>> uploadFilesV1(
-            @Parameter(name = "noticeId", description = "삭제하고자 하는 공고의 id입니다.")
+            @Parameter(name = "files", description = "업로드하고자 하는 파일 배열입니다.")
             @RequestParam MultipartFile[] files
     ) {
         Long memberId = 1L; //TODO: security
@@ -67,7 +80,17 @@ public class UploadController {
      * 파일 삭제
      */
     @Operation(summary = "파일 삭제", description = "전달받은 id 배열로 파일을 삭제합니다.", operationId = "deleteFiles")
-    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
+    @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content(
+            schema = @Schema(implementation = CommonResponseDto.class), examples = { @ExampleObject(value = """
+{
+  "status": "200 OK",
+  "timestamp": "2023-06-10T09:19:08.550Z",
+  "message": "SUCCESS",
+  "data": {
+    "uploadIdList" : [1, 2, 3, 4]
+  }
+}
+""")})) @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @DeleteMapping("")
     public CommonResponseDto<Map<String, List<Long>>> deleteFilesV1(
             @Validated @RequestBody final DeleteFilesRequestDto dto

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/FavoriteResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/FavoriteResponseDto.java
@@ -1,8 +1,15 @@
 package meet.myo.dto.response;
 
-import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import meet.myo.dto.schema.CatSummarySchema;
 
+@Schema(name = "Favorite")
+@Getter
 public class FavoriteResponseDto {
+    private Long favoriteId;
+    private Long memberId;
+    private CatSummarySchema cat;
 
     public static FavoriteResponseDto fromEntity() {
         return new FavoriteResponseDto();

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/MemberAuthorityResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/MemberAuthorityResponseDto.java
@@ -1,6 +1,16 @@
 package meet.myo.dto.response;
 
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.Getter;
+
+import java.util.List;
+
+@Hidden
+@Getter
 public class MemberAuthorityResponseDto {
+
+    private Long memberId;
+    private List<String> authorities;
 
     public static MemberAuthorityResponseDto fromEntity() {
         return new MemberAuthorityResponseDto();

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/MemberResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/MemberResponseDto.java
@@ -1,13 +1,19 @@
 package meet.myo.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
 import meet.myo.domain.Member;
 
+@Schema(name = "member")
+@Getter
 public class MemberResponseDto {
 
     private String name;
     private String email;
     private String nickName;
     private String phoneNumber;
+    private String profileImage;
+    private String oauthType;
 
     public static MemberResponseDto fromEntity(Member member) {
         MemberResponseDto dto = new MemberResponseDto();
@@ -15,6 +21,8 @@ public class MemberResponseDto {
         dto.email = member.getEmail();
         dto.nickName = member.getNickName();
         dto.phoneNumber = member.getPhoneNumber();
+        dto.profileImage = member.getProfileImage().getUrl();
+        dto.oauthType = member.getOauth().getOauthType().toString();
         return dto;
     }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/MemberUpdateResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/MemberUpdateResponseDto.java
@@ -10,12 +10,14 @@ public class MemberUpdateResponseDto {
     private String name;
     private String nickName;
     private String phoneNumber;
+    private String profileImage;
 
     public static MemberUpdateResponseDto fromEntity(Member member) {
         MemberUpdateResponseDto dto = new MemberUpdateResponseDto();
         dto.name = member.getName();
         dto.nickName = member.getNickName();
         dto.phoneNumber = member.getPhoneNumber();
+        dto.profileImage = member.getProfileImage().getUrl();
         return dto;
     }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/OauthUpdateResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/OauthUpdateResponseDto.java
@@ -8,13 +8,10 @@ import meet.myo.dto.request.OauthUpdateRequestDto;
 @Getter
 public class OauthUpdateResponseDto {
     private String oauthType;
-    private String oauthId;
 
-    // 객체 생성 패턴 : 빌더/스태틱 메서드
     public static OauthUpdateResponseDto fromEntity(Member member) {
         OauthUpdateResponseDto dto = new OauthUpdateResponseDto();
         dto.oauthType = member.getOauth().getOauthType().toString();
-        dto.oauthId = member.getOauth().getOauthId();
         return dto;
     }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptApplicationResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptApplicationResponseDto.java
@@ -1,8 +1,10 @@
 package meet.myo.dto.response.adopt;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import meet.myo.dto.schema.AuthorSchema;
 
+@Schema(name = "AdoptApplication")
 @Getter
 public class AdoptApplicationResponseDto {
 

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeCommentResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeCommentResponseDto.java
@@ -1,8 +1,10 @@
 package meet.myo.dto.response.adopt;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import meet.myo.dto.schema.AuthorSchema;
 
+@Schema(name = "AdoptNoticeComment")
 @Getter
 public class AdoptNoticeCommentResponseDto {
 

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeResponseDto.java
@@ -7,6 +7,7 @@ import meet.myo.dto.schema.CatResponseSchema;
 import meet.myo.dto.schema.UploadSummarySchema;
 
 @Getter
+@Schema(name = "AdoptNoticeDetail")
 public class AdoptNoticeResponseDto {
 
     private Long noticeId;
@@ -15,7 +16,7 @@ public class AdoptNoticeResponseDto {
 
     private CatResponseSchema cat;
 
-    private UploadSummarySchema fileSummary;
+    private UploadSummarySchema thumbnail;
 
     private String status;
 

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeSummaryResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeSummaryResponseDto.java
@@ -1,0 +1,24 @@
+package meet.myo.dto.response.adopt;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(name = "AdoptNoticeSummary")
+@Getter
+public class AdoptNoticeSummaryResponseDto {
+    private Long noticeId;
+    private String noticeTitle;
+    private String noticeStatus;
+    private String thumbnail;
+    private String authorName;
+    private String catName;
+    private String catSpecies;
+    private String shelterCity; //    SEOUL, SEJONG, BUSAN, DAEGU, INCHEON, GWANGJU, ULSAN, DAEJEON,
+                                // GYEONGGI, GANGWON, CHUNGCHEONG_BUK, CHUNGCHEONG_NAM, JEOLLA_BUK, JEOLLA_NAM,
+                                // GYEONGSANG_BUK, GYEONGSANG_NAM, JEJU
+
+
+    public static AdoptNoticeSummaryResponseDto fromEntity() {
+        return new AdoptNoticeSummaryResponseDto();
+    }
+}

--- a/MyohanMeeting/src/main/java/meet/myo/dto/schema/CatRequestSchema.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/schema/CatRequestSchema.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 import java.util.List;
 
-@Schema(name = "cat")
+@Schema(name = "catCreateForm")
 @Getter
 public class CatRequestSchema {
 

--- a/MyohanMeeting/src/main/java/meet/myo/dto/schema/CatSummarySchema.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/schema/CatSummarySchema.java
@@ -1,0 +1,17 @@
+package meet.myo.dto.schema;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(name = "CatSummary")
+@Getter
+public class CatSummarySchema {
+    private Long catId;
+    private String catName;
+    private String catSpecies;
+    private String catPicture;
+    private Long noticeId;
+    private String shelterCity; //    SEOUL, SEJONG, BUSAN, DAEGU, INCHEON, GWANGJU, ULSAN, DAEJEON,
+                                // GYEONGGI, GANGWON, CHUNGCHEONG_BUK, CHUNGCHEONG_NAM, JEOLLA_BUK, JEOLLA_NAM,
+                                // GYEONGSANG_BUK, GYEONGSANG_NAM, JEJU
+}

--- a/MyohanMeeting/src/main/java/meet/myo/service/AdoptNoticeService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/AdoptNoticeService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import meet.myo.dto.request.adopt.*;
 import meet.myo.dto.response.adopt.AdoptNoticeCommentResponseDto;
 import meet.myo.dto.response.adopt.AdoptNoticeResponseDto;
+import meet.myo.dto.response.adopt.AdoptNoticeSummaryResponseDto;
 import meet.myo.repository.AdoptNoticeRepoImpl;
 import meet.myo.repository.AdoptNoticeRepository;
 import meet.myo.search.AdoptNoticeSearch;
@@ -26,16 +27,16 @@ public class AdoptNoticeService {
      * 공고목록 전체 조회
      */
     @Transactional(readOnly = true)
-    public List<AdoptNoticeResponseDto> getAdoptNoticeList(Pageable pageable, AdoptNoticeSearch search) {
-        return List.of(AdoptNoticeResponseDto.fromEntity());
+    public List<AdoptNoticeSummaryResponseDto> getAdoptNoticeList(Pageable pageable, AdoptNoticeSearch search) {
+        return List.of(AdoptNoticeSummaryResponseDto.fromEntity());
     }
 
     /**
      * 특정 회원의 공고목록 전체 조회
      */
     @Transactional(readOnly = true)
-    public List<AdoptNoticeResponseDto> getMyAdoptNoticeList(Long memberId, Pageable pageable, String ordered) {
-        return List.of(AdoptNoticeResponseDto.fromEntity());
+    public List<AdoptNoticeSummaryResponseDto> getMyAdoptNoticeList(Long memberId, Pageable pageable, String ordered) {
+        return List.of(AdoptNoticeSummaryResponseDto.fromEntity());
     }
 
     /**


### PR DESCRIPTION
- 200 응답 시 별도의 dto 없이 Map으로 응답하는 메서드에 example 추가
- dto에 클래스 레벨 Schema 어노테이션 추가
- Notice, Cat summary dto 추가
- Notice 썸네일 필드명 thumbnail로 수정
- Favorite, MemberAuthority dto 작업
- Member 관련 dto에 profileImage 추가
- Oauth dto에서 id 필드 삭제