### PR TITLE
Fix/멤버 권한 관련 설정 추가

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/config/SecurityConfig.java
+++ b/MyohanMeeting/src/main/java/meet/myo/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/v1/auth/signin/direct").permitAll()
                 .requestMatchers(HttpMethod.GET, "/v1/auth/signin/oauth").permitAll()
                 .requestMatchers(HttpMethod.GET, "/v1/member/email").permitAll()
-                .requestMatchers(HttpMethod.GET, "/v1/member/nickName").permitAll()
+                .requestMatchers(HttpMethod.GET, "/v1/member/nickname").permitAll()
                 .anyRequest().authenticated()
 
                 // JwtSecurityConfig 적용

--- a/MyohanMeeting/src/main/java/meet/myo/config/SecurityConfig.java
+++ b/MyohanMeeting/src/main/java/meet/myo/config/SecurityConfig.java
@@ -52,12 +52,14 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/favicon.ico").permitAll()
                 .requestMatchers(HttpMethod.GET, "/h2/console").permitAll()
                 .requestMatchers(HttpMethod.GET, "/h2/console/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/swagger-ui/index.html").permitAll()
+                .requestMatchers(HttpMethod.GET, "/v3/api-docs").permitAll()
 
                 // 회원가입, 로그인, 중복확인 요청은 권한 없이도 permit하도록 설정
                 .requestMatchers(HttpMethod.POST, "/v1/member/direct").permitAll()
                 .requestMatchers(HttpMethod.POST, "v1/member/oauth").permitAll()
-                .requestMatchers(HttpMethod.GET, "/v1/auth/signin/direct").permitAll()
-                .requestMatchers(HttpMethod.GET, "/v1/auth/signin/oauth").permitAll()
+                .requestMatchers(HttpMethod.POST, "/v1/auth/signin/direct").permitAll()
+                .requestMatchers(HttpMethod.POST, "/v1/auth/signin/oauth").permitAll()
                 .requestMatchers(HttpMethod.GET, "/v1/member/email").permitAll()
                 .requestMatchers(HttpMethod.GET, "/v1/member/nickname").permitAll()
                 .anyRequest().authenticated()

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptApplicationController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptApplicationController.java
@@ -10,9 +10,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import meet.myo.config.SecurityUtil;
 import meet.myo.dto.request.adopt.AdoptApplicationRequestDto;
 import meet.myo.dto.response.adopt.AdoptApplicationResponseDto;
 import meet.myo.dto.response.CommonResponseDto;
+import meet.myo.exception.NotAuthenticatedException;
 import meet.myo.service.AdoptApplicationService;
 import meet.myo.springdoc.annotations.ApiResponseAuthority;
 import meet.myo.springdoc.annotations.ApiResponseCommon;
@@ -20,6 +22,8 @@ import meet.myo.springdoc.annotations.ApiResponseResource;
 import meet.myo.springdoc.annotations.ApiResponseSignin;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,6 +35,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/adoption/applications")
+@PreAuthorize("hasAnyRole('ROLE_USER')")
 public class AdoptApplicationController {
 
     private final AdoptApplicationService adoptApplicationService;
@@ -78,7 +83,7 @@ public class AdoptApplicationController {
                     in = ParameterIn.QUERY, example = "-createdAt,applicationCount")
             @RequestParam(value = "sort", required = false) String sort
     ) {
-        Long memberId = 1L; // TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         Pageable pageable = PageRequest.of(page, size);
         return CommonResponseDto.<List<AdoptApplicationResponseDto>>builder()
                 .data(adoptApplicationService.getMyAdoptApplicationList(memberId, pageable, sort))
@@ -115,7 +120,7 @@ public class AdoptApplicationController {
                     in = ParameterIn.QUERY, example = "-createdAt,applicationCount")
             @RequestParam(value = "sort", required = false) String sort
     ) {
-        Long memberId = 1L; // TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         Pageable pageable = PageRequest.of(page, size);
         return CommonResponseDto.<List<AdoptApplicationResponseDto>>builder()
                 .data(adoptApplicationService.getAdoptApplicationListByNotice(memberId, noticeId, pageable, sort))
@@ -141,7 +146,7 @@ public class AdoptApplicationController {
     public CommonResponseDto<Map<String, Long>> createApplicationV1(
             @Validated @RequestBody final AdoptApplicationRequestDto dto
     ) {
-        Long memberId = 1L; // TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<Map<String, Long>>builder()
                 .data(Map.of("applicationId", adoptApplicationService.createAdoptApplication(memberId, dto)))
                 .build();
@@ -159,7 +164,7 @@ public class AdoptApplicationController {
 
             @Validated @RequestBody final AdoptApplicationRequestDto dto
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<AdoptApplicationResponseDto>builder()
                 .data(adoptApplicationService.updateAdoptApplication(memberId, applicationId, dto))
                 .build();
@@ -185,7 +190,7 @@ public class AdoptApplicationController {
             @Parameter(name = "applicationId", description = "삭제하고자 하는 분양신청의 id입니다.")
             @PathVariable(name = "applicationId") Long applicationId
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<Map<String, Long>>builder()
                 .data(Map.of("applicationId", adoptApplicationService.deleteAdoptApplication(memberId, applicationId)))
                 .build();

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeCommentController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeCommentController.java
@@ -9,14 +9,17 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import meet.myo.config.SecurityUtil;
 import meet.myo.dto.request.adopt.AdoptNoticeCommentRequestDto;
 import meet.myo.dto.response.adopt.AdoptNoticeCommentResponseDto;
 import meet.myo.dto.response.CommonResponseDto;
+import meet.myo.exception.NotAuthenticatedException;
 import meet.myo.service.AdoptNoticeService;
 import meet.myo.springdoc.annotations.ApiResponseAuthority;
 import meet.myo.springdoc.annotations.ApiResponseCommon;
 import meet.myo.springdoc.annotations.ApiResponseResource;
 import meet.myo.springdoc.annotations.ApiResponseSignin;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,6 +30,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/adoption/notices")
+@PreAuthorize("hasAnyRole('ROLE_USER')")
 public class AdoptNoticeCommentController {
 
     private final AdoptNoticeService adoptNoticeService;
@@ -66,7 +70,7 @@ public class AdoptNoticeCommentController {
     public CommonResponseDto<Map<String, Long>> createNoticeCommentV1(
             @Validated @RequestBody final AdoptNoticeCommentRequestDto dto
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<Map<String, Long>>builder()
                 .data(Map.of("noticeId", adoptNoticeService.createAdoptNoticeComment(memberId, dto)))
                 .build();
@@ -85,7 +89,7 @@ public class AdoptNoticeCommentController {
 
             @Validated @RequestBody final AdoptNoticeCommentRequestDto dto
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<AdoptNoticeCommentResponseDto>builder()
                 .data(adoptNoticeService.updateAdoptNoticeComment(memberId, noticeCommentId, dto))
                 .build();
@@ -112,7 +116,7 @@ public class AdoptNoticeCommentController {
             @Parameter(name = "noticeCommentId", description = "삭제하고자 하는 댓글의 id입니다.")
             @PathVariable(name = "noticeCommentId") Long noticeCommentId
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<Map<String, Long>>builder()
                 .data(Map.of("noticeCommentId", adoptNoticeService.deleteAdoptNoticeComment(memberId, noticeCommentId)))
                 .build();

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
@@ -10,16 +10,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import meet.myo.config.SecurityUtil;
 import meet.myo.dto.request.adopt.AdoptNoticeRequestDto;
 import meet.myo.dto.request.adopt.AdoptNoticeStatusUpdateRequestDto;
 import meet.myo.dto.response.adopt.AdoptNoticeResponseDto;
 import meet.myo.dto.response.CommonResponseDto;
 import meet.myo.dto.response.adopt.AdoptNoticeSummaryResponseDto;
+import meet.myo.exception.NotAuthenticatedException;
 import meet.myo.search.AdoptNoticeSearch;
 import meet.myo.service.AdoptNoticeService;
 import meet.myo.springdoc.annotations.*;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,6 +33,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/adoption/notices")
+@PreAuthorize("hasAnyRole('ROLE_USER')")
 public class AdoptNoticeController {
 
     private final AdoptNoticeService adoptNoticeService;
@@ -162,7 +166,7 @@ public class AdoptNoticeController {
                     in = ParameterIn.QUERY, example = "-createdAt,applicationCount")
             @RequestParam(value = "sort", required = false) String sort
     ) {
-        Long memberId = 1L; // TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         Pageable pageable = PageRequest.of(page, size);
         return CommonResponseDto.<List<AdoptNoticeSummaryResponseDto>>builder()
                 .data(adoptNoticeService.getMyAdoptNoticeList(memberId, pageable, sort))
@@ -179,7 +183,6 @@ public class AdoptNoticeController {
             @Parameter(name = "noticeId", description = "조회하고자 하는 공고의 id입니다.")
             @PathVariable(name = "noticeId") Long noticeId
     ) {
-        if (noticeId == 1L) throw new IllegalArgumentException("test");
         return CommonResponseDto.<AdoptNoticeResponseDto>builder()
                 .data(adoptNoticeService.getAdoptNotice(noticeId))
                 .build();
@@ -203,7 +206,7 @@ public class AdoptNoticeController {
     @SecurityRequirement(name = "JWT")
     @PostMapping("")
     public CommonResponseDto<Map<String, Long>> createNoticeV1(@Validated @RequestBody final AdoptNoticeRequestDto dto) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<Map<String, Long>>builder()
                 .data(Map.of("noticeId", adoptNoticeService.createAdoptNotice(memberId, dto)))
                 .build();
@@ -222,7 +225,7 @@ public class AdoptNoticeController {
 
             @Validated @RequestBody final AdoptNoticeStatusUpdateRequestDto dto
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<AdoptNoticeResponseDto>builder()
                 .data(adoptNoticeService.updateAdoptNoticeStatus(memberId, noticeId, dto))
                 .build();
@@ -241,7 +244,7 @@ public class AdoptNoticeController {
 
             @Validated @RequestBody final AdoptNoticeRequestDto dto
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<AdoptNoticeResponseDto>builder()
                 .data(adoptNoticeService.updateAdoptNotice(memberId, noticeId, dto))
                 .build();
@@ -268,7 +271,7 @@ public class AdoptNoticeController {
             @Parameter(name = "noticeId", description = "삭제하고자 하는 공고의 id입니다.")
             @PathVariable(name = "noticeId") Long noticeId
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<Map<String, Long>>builder()
                 .data(Map.of("noticeId", adoptNoticeService.deleteAdoptNotice(memberId, noticeId)))
                 .build();

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AuthController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AuthController.java
@@ -1,17 +1,22 @@
 package meet.myo.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import meet.myo.dto.request.auth.DirectSignInRequestDto;
 import meet.myo.dto.request.auth.OauthSignInRequestDto;
+import meet.myo.dto.request.auth.TokenRefreshRequestDto;
 import meet.myo.dto.response.CommonResponseDto;
 import meet.myo.jwt.TokenDto;
 import meet.myo.service.AuthService;
+import meet.myo.springdoc.annotations.ApiResponseAuthority;
+import meet.myo.springdoc.annotations.ApiResponseCommon;
+import meet.myo.springdoc.annotations.ApiResponseSignin;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Authentication", description = "인증 관련 기능")
 @RestController
@@ -20,17 +25,48 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final AuthService authService;
 
-    @GetMapping("/signin/direct")
-    public CommonResponseDto<TokenDto> directSignInV1(@Validated @RequestBody final DirectSignInRequestDto dto) {
+    /**
+     * 이메일 로그인
+     */
+    @Operation(summary = "이메일 회원 로그인", description = "이메일과 비밀번호로 직접 로그인합니다.", operationId = "directSignIn")
+    @ApiResponse(responseCode = "200") @ApiResponseCommon
+    @SecurityRequirement(name = "")
+    @PostMapping("/signin/direct")
+    public CommonResponseDto<TokenDto> directSignInV1(
+            @Validated @RequestBody final DirectSignInRequestDto dto
+    ) {
         return CommonResponseDto.<TokenDto>builder()
                 .data(authService.getToken(dto))
                 .build();
     }
 
-    @GetMapping("/signin/oauth")
-    public CommonResponseDto<TokenDto> oauthSignInV1(@Validated @RequestBody final OauthSignInRequestDto dto) {
+    /**
+     * oauth 로그인
+     */
+    @Operation(summary = "SNS 회원 로그인", description = "SNS 정보로 로그인합니다.", operationId = "oauthSignIn")
+    @ApiResponse(responseCode = "200") @ApiResponseCommon
+    @SecurityRequirement(name = "")
+    @PostMapping("/signin/oauth")
+    public CommonResponseDto<TokenDto> oauthSignInV1(
+            @Validated @RequestBody final OauthSignInRequestDto dto
+    ) {
         return CommonResponseDto.<TokenDto>builder()
                 .data(authService.getToken(dto))
+                .build();
+    }
+
+    /**
+     * 토큰 리프레시
+     */
+    @Operation(summary = "토큰 리프레시", description = "토큰 리프레시를 요청합니다.", operationId = "refreshToken")
+    @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin @ApiResponseAuthority
+    @SecurityRequirement(name = "")
+    @GetMapping("/refresh")
+    public CommonResponseDto<TokenDto> refreshTokenV1(
+            @Validated @RequestBody final TokenRefreshRequestDto dto
+    ) {
+        return CommonResponseDto.<TokenDto>builder()
+                .data(authService.tokenRefresh(dto.getRefreshToken()))
                 .build();
     }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AuthController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AuthController.java
@@ -61,7 +61,7 @@ public class AuthController {
     @Operation(summary = "토큰 리프레시", description = "토큰 리프레시를 요청합니다.", operationId = "refreshToken")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin @ApiResponseAuthority
     @SecurityRequirement(name = "")
-    @GetMapping("/refresh")
+    @PostMapping("/refresh")
     public CommonResponseDto<TokenDto> refreshTokenV1(
             @Validated @RequestBody final TokenRefreshRequestDto dto
     ) {

--- a/MyohanMeeting/src/main/java/meet/myo/controller/FavoriteController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/FavoriteController.java
@@ -10,9 +10,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import meet.myo.config.SecurityUtil;
 import meet.myo.dto.request.CreateFavoriteRequestDto;
 import meet.myo.dto.response.CommonResponseDto;
 import meet.myo.dto.response.FavoriteResponseDto;
+import meet.myo.exception.NotAuthenticatedException;
 import meet.myo.service.FavoriteService;
 import meet.myo.springdoc.annotations.ApiResponseAuthority;
 import meet.myo.springdoc.annotations.ApiResponseCommon;
@@ -20,6 +22,7 @@ import meet.myo.springdoc.annotations.ApiResponseResource;
 import meet.myo.springdoc.annotations.ApiResponseSignin;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,6 +34,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/favorite")
+@PreAuthorize("hasAnyRole('ROLE_USER')")
 public class FavoriteController {
 
     private final FavoriteService favoriteService;
@@ -52,7 +56,7 @@ public class FavoriteController {
             @Parameter(name = "limit", description = "리미트를 설정합니다.", in = ParameterIn.QUERY)
             @RequestParam(value = "limit", required = false, defaultValue = "100") int size
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         Pageable pageable = PageRequest.of(page, size);
         return CommonResponseDto.<List<FavoriteResponseDto>>builder()
                 .data(favoriteService.getFavoriteList(memberId, pageable))
@@ -79,7 +83,7 @@ public class FavoriteController {
     public CommonResponseDto<Map<String, Long>> createFavoriteV1(
             @Validated @RequestBody final CreateFavoriteRequestDto dto
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<Map<String, Long>>builder()
                 .data(Map.of("favoriteId", favoriteService.createFavorite(memberId, dto)))
                 .build();
@@ -106,7 +110,7 @@ public class FavoriteController {
             @Parameter(name = "favoriteId", description = "삭제하고자 하는 최애친구의 id입니다.")
             @PathVariable(name = "favoriteId") Long favoriteId
     ) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<Map<String, Long>>builder()
                 .data(Map.of("favoriteId", favoriteService.deleteFavorite(memberId, favoriteId)))
                 .build();

--- a/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
@@ -1,6 +1,8 @@
 package meet.myo.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -66,9 +68,10 @@ public class MemberController {
     @SecurityRequirement(name = "")
     @GetMapping("/email")
     public CommonResponseDto emailDuplicationCheckV1(
-            @Validated @RequestBody final EmailDuplicationCheckRequestDto dto
+            @Parameter(name = "email", description = "중복을 확인할 이메일입니다.", in = ParameterIn.QUERY)
+            @RequestParam(value = "email") String email
     ) {
-        memberService.emailDuplicationCheck(dto);
+        memberService.emailDuplicationCheck(email);
         return CommonResponseDto.builder().build();
     }
 
@@ -81,9 +84,10 @@ public class MemberController {
     @SecurityRequirement(name = "")
     @GetMapping("/nickname")
     public CommonResponseDto nicknameDuplicationCheckV1(
-            @Validated @RequestBody final NicknameDuplicationCheckRequestDto dto
+            @Parameter(name = "nickname", description = "중복을 확인할 닉네임입니다.", in = ParameterIn.QUERY)
+            @RequestParam(value = "nickname") String nickname
     ) {
-        memberService.nicknameDuplicationCheck(dto);
+        memberService.nicknameDuplicationCheck(nickname);
         return CommonResponseDto.builder().build();
     }
 

--- a/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
@@ -5,15 +5,18 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import meet.myo.config.SecurityUtil;
 import meet.myo.dto.request.member.*;
 import meet.myo.dto.response.*;
 import meet.myo.dto.response.member.EmailUpdateResponseDto;
 import meet.myo.dto.response.member.MemberResponseDto;
 import meet.myo.dto.response.member.MemberUpdateResponseDto;
 import meet.myo.dto.response.member.OauthUpdateResponseDto;
+import meet.myo.exception.NotAuthenticatedException;
 import meet.myo.service.MemberService;
 import meet.myo.springdoc.annotations.ApiResponseCommon;
 import meet.myo.springdoc.annotations.ApiResponseSignin;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -73,14 +76,14 @@ public class MemberController {
      * 닉네임 중복확인
      */
     @Tag(name = "Sign Up", description = "회원가입 관련 기능")
-    @Operation(summary = "닉네임 중복확인", description = "가입 시 닉네임 중복여부를 확인합니다.", operationId = "nickNameDuplicationCheck")
+    @Operation(summary = "닉네임 중복확인", description = "가입 시 닉네임 중복여부를 확인합니다.", operationId = "nicknameDuplicationCheck")
     @ApiResponse(responseCode = "200") @ApiResponseCommon
     @SecurityRequirement(name = "")
-    @GetMapping("/nickName")
-    public CommonResponseDto nickNameDuplicationCheckV1(
-            @Validated @RequestBody final NickNameDuplicationCheckRequestDto dto
+    @GetMapping("/nickname")
+    public CommonResponseDto nicknameDuplicationCheckV1(
+            @Validated @RequestBody final NicknameDuplicationCheckRequestDto dto
     ) {
-        memberService.nickNameDuplicationCheck(dto);
+        memberService.nicknameDuplicationCheck(dto);
         return CommonResponseDto.builder().build();
     }
 
@@ -92,9 +95,10 @@ public class MemberController {
     @Operation(summary = "인증 이메일 발송", description = "가입 후 이메일 주소 인증을 위한 이메일을 발송합니다.", operationId = "sendCertificationEmail")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @PostMapping("/certification")
     public CommonResponseDto sendCertificationEmailV1() {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         memberService.sendCertificationEmail(memberId);
         return CommonResponseDto.builder().build();
     }
@@ -106,9 +110,10 @@ public class MemberController {
     @Operation(summary = "메일인증 코드 검증", description = "이메일 주소 인증코드를 검증합니다.", operationId = "verifyCertificationEmail")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @PutMapping("/certification")
     public CommonResponseDto verifyCertificationEmailV1(@Validated @RequestBody final CertifyEmailRequestDto dto) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         memberService.verifyCertificationEmail(memberId, dto);
         return CommonResponseDto.builder().build(); // TODO: 리턴값 어떻게 할지 생각
     }
@@ -120,9 +125,10 @@ public class MemberController {
     @Operation(summary = "내 정보 보기", description = "자신의 회원정보를 확인합니다.", operationId = "getMyInfo")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @GetMapping("")
     public CommonResponseDto<MemberResponseDto> getMyInfoV1() {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<MemberResponseDto>builder()
                 .data(memberService.getMemberById(memberId))
                 .build();
@@ -135,9 +141,10 @@ public class MemberController {
     @Operation(summary = "내 정보 수정", description = "자신의 회원정보를 수정합니다.", operationId = "updateMyInfo")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @PatchMapping("")
     public CommonResponseDto<MemberUpdateResponseDto> updateMyInfoV1(@Validated @RequestBody final MemberUpdateRequestDto dto) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<MemberUpdateResponseDto>builder()
                 .data(memberService.updateMember(memberId, dto))
                 .build();
@@ -150,9 +157,10 @@ public class MemberController {
     @Operation(summary = "이메일 수정", description = "이메일을 수정합니다.", operationId = "updateEmail")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @PutMapping("/email")
     public CommonResponseDto<EmailUpdateResponseDto> updateEmailV1(@Validated @RequestBody final EmailUpdateRequestDto dto) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<EmailUpdateResponseDto>builder()
                 .data(memberService.updateEmail(memberId, dto))
                 .build();
@@ -167,9 +175,10 @@ public class MemberController {
             operationId = "updatePassword")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @PutMapping("/password")
     public CommonResponseDto updatePasswordV1(@Validated @RequestBody final PasswordUpdateRequestDto dto) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         memberService.updatePassword(memberId, dto);
         return CommonResponseDto.builder().build();
     }
@@ -183,9 +192,10 @@ public class MemberController {
             operationId = "updateOauth")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @PutMapping("/oauth")
     public CommonResponseDto<OauthUpdateResponseDto> updateOauthV1(@Validated @RequestBody final OauthUpdateRequestDto dto) {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<OauthUpdateResponseDto>builder()
                 .data(memberService.updateOauth(memberId, dto))
                 .build();
@@ -198,9 +208,10 @@ public class MemberController {
     @Operation(summary = "SNS 로그인 정보 삭제", description = "연결된 SNS 로그인 정보를 삭제합니다.", operationId = "removeOauth")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @DeleteMapping("/oauth")
     public CommonResponseDto removeOauthV1() {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         memberService.deleteOauth(memberId);
         return CommonResponseDto.builder().build();
     }
@@ -212,9 +223,10 @@ public class MemberController {
     @Operation(summary = "회원 탈퇴", description = "서비스에서 탈퇴합니다.", operationId = "resign")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @DeleteMapping("")
     public CommonResponseDto resignV1() {
-        Long memberId = 1L; //TODO: security
+        Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         memberService.resign(memberId);
         return CommonResponseDto.builder().build();
     }

--- a/MyohanMeeting/src/main/java/meet/myo/domain/Member.java
+++ b/MyohanMeeting/src/main/java/meet/myo/domain/Member.java
@@ -24,7 +24,7 @@ public class Member extends BaseAuditingListener {
 
     private String password;
 
-    private String nickName;
+    private String nickname;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id")
@@ -45,19 +45,19 @@ public class Member extends BaseAuditingListener {
     private Oauth oauth;
 
     @Builder(builderClassName = "DirectJoinMemberBuilder", builderMethodName = "directJoinBuilder")
-    Member(String email, String password, String nickName, String phoneNumber) {
+    Member(String email, String password, String nickname, String phoneNumber) {
         this.email = email;
         this.password = password;
-        this.nickName = nickName;
+        this.nickname = nickname;
         this.phoneNumber = phoneNumber;
         this.certified = Certified.NOT_CERTIFIED; // 미인증을 기본값으로 세팅
     }
 
     @Builder(builderClassName = "OauthJoinMemberBuilder", builderMethodName = "oauthJoinBuilder")
-    Member(OauthType oauthType, String oauthId, String email, String nickName) {
+    Member(OauthType oauthType, String oauthId, String email, String nickname) {
         this.email = email;
         this.oauth = Oauth.createOauth(oauthType, oauthId);
-        this.nickName = nickName;
+        this.nickname = nickname;
         this.certified = Certified.NOT_CERTIFIED; // 미인증을 기본값으로 세팅
     }
 
@@ -69,8 +69,8 @@ public class Member extends BaseAuditingListener {
         this.password = password;
     }
 
-    public void updateNickName(String nickName) {
-        this.nickName = nickName;
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
     }
 
     public void updateProfileImage(Upload upload) {

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/DirectSignInRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/DirectSignInRequestDto.java
@@ -1,9 +1,11 @@
 package meet.myo.dto.request.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
+@Schema(name = "directSignInRequest")
 @Getter
 public class DirectSignInRequestDto implements SignInRequestDto {
 

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/OauthSignInRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/OauthSignInRequestDto.java
@@ -1,7 +1,9 @@
 package meet.myo.dto.request.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+@Schema(name = "oauthSignInRequest")
 @Getter
 public class OauthSignInRequestDto implements SignInRequestDto {
     private String oauthType;

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/TokenRefreshRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/TokenRefreshRequestDto.java
@@ -1,0 +1,10 @@
+package meet.myo.dto.request.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(name = "tokenRefreshRequest")
+@Getter
+public class TokenRefreshRequestDto {
+    private String refreshToken;
+}

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/EmailDuplicationCheckRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/EmailDuplicationCheckRequestDto.java
@@ -1,8 +1,0 @@
-package meet.myo.dto.request.member;
-
-import lombok.Getter;
-
-@Getter
-public class EmailDuplicationCheckRequestDto {
-    private String email;
-}

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberDirectCreateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberDirectCreateRequestDto.java
@@ -13,7 +13,7 @@ public class MemberDirectCreateRequestDto {
     private String email;
     @NotBlank(message = "PASSWORD_IS_MANDATORY")
     private String password;
-    private String nickName;
+    private String nickname;
     private String phoneNumber;
     private String profileImage;
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberOauthCreateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberOauthCreateRequestDto.java
@@ -9,5 +9,5 @@ public class MemberOauthCreateRequestDto {
     private String oauthType;
     private String oauthId;
     private String email;
-    private String nickName;
+    private String nickname;
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberUpdateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberUpdateRequestDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public class MemberUpdateRequestDto {
     private String name;
-    private String nickName;
+    private String nickname;
     private String phoneNumber;
     private String profileImage;
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/NickNameDuplicationCheckRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/NickNameDuplicationCheckRequestDto.java
@@ -3,6 +3,6 @@ package meet.myo.dto.request.member;
 import lombok.Getter;
 
 @Getter
-public class NickNameDuplicationCheckRequestDto {
-    private String nickName;
+public class NicknameDuplicationCheckRequestDto {
+    private String nickname;
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/NickNameDuplicationCheckRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/NickNameDuplicationCheckRequestDto.java
@@ -1,8 +1,0 @@
-package meet.myo.dto.request.member;
-
-import lombok.Getter;
-
-@Getter
-public class NicknameDuplicationCheckRequestDto {
-    private String nickname;
-}

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/AuthorResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/AuthorResponseDto.java
@@ -8,13 +8,13 @@ import meet.myo.domain.Member;
 @Getter
 public class AuthorResponseDto {
     private Long authorId;
-    private String nickName;
+    private String nickname;
     private String profileImageUrl;
 
     public static AuthorResponseDto fromEntity(Member entity) {
         AuthorResponseDto author = new AuthorResponseDto();
         author.authorId = entity.getId();
-        author.nickName = entity.getNickName();
+        author.nickname = entity.getNickname();
         author.profileImageUrl = entity.getProfileImage().getUrl(); //TODO: QueryDsl로 최적화
         return author;
     }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeSummaryResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeSummaryResponseDto.java
@@ -29,7 +29,7 @@ public class AdoptNoticeSummaryResponseDto {
         dto.noticeTitle = entity.getTitle();
         dto.noticeStatus = entity.getNoticeStatus().toString();
         dto.thumbnail = entity.getThumbnail().toString();
-        dto.authorName = entity.getMember().getNickName();
+        dto.authorName = entity.getMember().getNickname();
         dto.catName = entity.getCat().getName();
         dto.catSpecies = entity.getCat().getSpecies();
         dto.shelterCity = entity.getShelter().getCity().toString();

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/member/MemberResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/member/MemberResponseDto.java
@@ -17,10 +17,10 @@ public class MemberResponseDto {
     public static MemberResponseDto fromEntity(Member member) {
         MemberResponseDto dto = new MemberResponseDto();
         dto.email = member.getEmail();
-        dto.phoneNumber = member.getPhoneNumber();
-        dto.profileImage = member.getProfileImage().getUrl();
-        dto.oauthType = member.getOauth().getOauthType().toString();
         dto.nickname = member.getNickname();
+        dto.phoneNumber = member.getPhoneNumber() != null ? member.getPhoneNumber() : null;
+        dto.profileImage = member.getProfileImage() != null ? member.getProfileImage().toString() : null;
+        dto.oauthType = member.getOauth() != null ? member.getOauth().getOauthType().toString() : null;
         return dto;
     }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/member/MemberResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/member/MemberResponseDto.java
@@ -9,7 +9,7 @@ import meet.myo.domain.Member;
 public class MemberResponseDto {
 
     private String email;
-    private String nickName;
+    private String nickname;
     private String phoneNumber;
     private String profileImage;
     private String oauthType;
@@ -17,10 +17,10 @@ public class MemberResponseDto {
     public static MemberResponseDto fromEntity(Member member) {
         MemberResponseDto dto = new MemberResponseDto();
         dto.email = member.getEmail();
-        dto.nickName = member.getNickName();
         dto.phoneNumber = member.getPhoneNumber();
         dto.profileImage = member.getProfileImage().getUrl();
         dto.oauthType = member.getOauth().getOauthType().toString();
+        dto.nickname = member.getNickname();
         return dto;
     }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/member/MemberUpdateResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/member/MemberUpdateResponseDto.java
@@ -5,13 +5,13 @@ import meet.myo.domain.Member;
 
 @Getter
 public class MemberUpdateResponseDto {
-    private String nickName;
+    private String nickname;
     private String phoneNumber;
     private String profileImage;
 
     public static MemberUpdateResponseDto fromEntity(Member member) {
         MemberUpdateResponseDto dto = new MemberUpdateResponseDto();
-        dto.nickName = member.getNickName();
+        dto.nickname = member.getNickname();
         dto.phoneNumber = member.getPhoneNumber();
         dto.profileImage = member.getProfileImage().getUrl();
         return dto;

--- a/MyohanMeeting/src/main/java/meet/myo/repository/AuthorityRepository.java
+++ b/MyohanMeeting/src/main/java/meet/myo/repository/AuthorityRepository.java
@@ -4,6 +4,9 @@ import meet.myo.domain.authority.Authority;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AuthorityRepository extends JpaRepository<Authority, Long> {
+    Optional<Authority> findByAuthorityName(String authorityName);
 }

--- a/MyohanMeeting/src/main/java/meet/myo/repository/MemberAuthorityRepository.java
+++ b/MyohanMeeting/src/main/java/meet/myo/repository/MemberAuthorityRepository.java
@@ -3,5 +3,8 @@ package meet.myo.repository;
 import meet.myo.domain.authority.MemberAuthority;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberAuthorityRepository extends JpaRepository<MemberAuthority, Long> {
+    List<MemberAuthority> findByMemberId(Long memberId);
 }

--- a/MyohanMeeting/src/main/java/meet/myo/repository/MemberRepository.java
+++ b/MyohanMeeting/src/main/java/meet/myo/repository/MemberRepository.java
@@ -17,6 +17,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByOauthOauthTypeAndOauthOauthIdAndDeletedAtNull(OauthType oauthType, String oauthId);
 
     // findOneBy
-    Optional<Member> findByNickNameAndDeletedAtNull(String nickName);
+    Optional<Member> findByNicknameAndDeletedAtNull(String nickname);
 
 }

--- a/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
@@ -5,19 +5,23 @@ import meet.myo.domain.EmailCertification;
 import meet.myo.domain.Member;
 import meet.myo.domain.Oauth;
 import meet.myo.domain.OauthType;
+import meet.myo.domain.authority.MemberAuthority;
 import meet.myo.dto.request.member.*;
 import meet.myo.dto.response.member.EmailUpdateResponseDto;
 import meet.myo.dto.response.member.MemberResponseDto;
 import meet.myo.dto.response.member.MemberUpdateResponseDto;
 import meet.myo.dto.response.member.OauthUpdateResponseDto;
 import meet.myo.exception.NotFoundException;
+import meet.myo.repository.AuthorityRepository;
 import meet.myo.repository.EmailCertificationRepository;
+import meet.myo.repository.MemberAuthorityRepository;
 import meet.myo.repository.MemberRepository;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -28,6 +32,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final EmailCertificationRepository emailCertificationRepository;
+    private final AuthorityRepository authorityRepository;
+    private final MemberAuthorityRepository memberAuthorityRepository;
 
     /**
      * 회원정보 조회
@@ -53,7 +59,10 @@ public class MemberService {
                 .nickName(dto.getNickName())
                 .phoneNumber(dto.getPhoneNumber())
                 .build();
+        MemberAuthority memberAuthority = MemberAuthority.createMemberAuthority(
+                member, authorityRepository.findByAuthorityName("ROLE_USER").orElseThrow(NotFoundException::new));
 
+        memberAuthorityRepository.save(memberAuthority);
         return memberRepository.save(member).getId();
     }
 
@@ -77,7 +86,10 @@ public class MemberService {
             memberBuilder.nickName(randomNickname);
         }
         Member member = memberBuilder.build();
+        MemberAuthority memberAuthority = MemberAuthority.createMemberAuthority(
+                member, authorityRepository.findByAuthorityName("ROLE_USER").orElseThrow(NotFoundException::new));
 
+        memberAuthorityRepository.save(memberAuthority);
         memberRepository.save(member);
         return member.getId();
     }
@@ -200,6 +212,9 @@ public class MemberService {
         Member member = memberRepository.findByIdAndDeletedAtNull(memberId)
                 .orElseThrow(() -> new NotFoundException("id에 해당하는 회원을 찾을 수 없습니다."));
         member.delete();
+
+        // 권한 삭제
+        memberAuthorityRepository.findByMemberId(member.getId()).forEach(MemberAuthority::delete);
         
         return member.getId();
     }

--- a/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
@@ -97,15 +97,15 @@ public class MemberService {
     /**
      * 이메일 중복체크
      */
-    public void emailDuplicationCheck(EmailDuplicationCheckRequestDto dto) {
-        validateEmailDuplication(dto.getEmail());
+    public void emailDuplicationCheck(String email) {
+        validateEmailDuplication(email);
     }
 
     /**
      * 닉네임 중복체크
      */
-    public void nicknameDuplicationCheck(NicknameDuplicationCheckRequestDto dto) {
-        validateNicknameDuplication(dto.getNickname());
+    public void nicknameDuplicationCheck(String nickname) {
+        validateNicknameDuplication(nickname);
     }
 
     /**

--- a/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
@@ -50,13 +50,13 @@ public class MemberService {
      */
     public Long directJoin(MemberDirectCreateRequestDto dto) {
         validateEmailDuplication(dto.getEmail());
-        validateNickNameDuplication(dto.getNickName());
+        validateNicknameDuplication(dto.getNickname());
 
         String encoded = passwordEncoder.encode(dto.getPassword());
         Member member = Member.directJoinBuilder()
                 .email(dto.getEmail())
                 .password(encoded)
-                .nickName(dto.getNickName())
+                .nickname(dto.getNickname())
                 .phoneNumber(dto.getPhoneNumber())
                 .build();
         MemberAuthority memberAuthority = MemberAuthority.createMemberAuthority(
@@ -77,13 +77,13 @@ public class MemberService {
                 .oauthType(dto.getOauthType() != null ? OauthType.valueOf(dto.getOauthType()) : null)
                 .oauthId(dto.getOauthId())
                 .email(dto.getEmail());
-        if (dto.getNickName() != null) {
-            validateNickNameDuplication(dto.getNickName());
-            memberBuilder.nickName(dto.getNickName());
+        if (dto.getNickname() != null) {
+            validateNicknameDuplication(dto.getNickname());
+            memberBuilder.nickname(dto.getNickname());
         } else {
             String randomNickname = createRandomNickname();
-            validateNickNameDuplication(randomNickname);
-            memberBuilder.nickName(randomNickname);
+            validateNicknameDuplication(randomNickname);
+            memberBuilder.nickname(randomNickname);
         }
         Member member = memberBuilder.build();
         MemberAuthority memberAuthority = MemberAuthority.createMemberAuthority(
@@ -104,8 +104,8 @@ public class MemberService {
     /**
      * 닉네임 중복체크
      */
-    public void nickNameDuplicationCheck(NickNameDuplicationCheckRequestDto dto) {
-        validateNickNameDuplication(dto.getNickName());
+    public void nicknameDuplicationCheck(NicknameDuplicationCheckRequestDto dto) {
+        validateNicknameDuplication(dto.getNickname());
     }
 
     /**
@@ -198,7 +198,7 @@ public class MemberService {
         Member member = memberRepository.findByIdAndDeletedAtNull(memberId)
                 .orElseThrow(() -> new NotFoundException("id에 해당하는 회원을 찾을 수 없습니다."));
 
-        member.updateNickName(dto.getNickName());
+        member.updateNickname(dto.getNickname());
         member.updatePhoneNumber(dto.getPhoneNumber());
 
         return MemberUpdateResponseDto.fromEntity(member);
@@ -230,8 +230,8 @@ public class MemberService {
                 });
     }
 
-    private void validateNickNameDuplication(String nickName) throws DuplicateKeyException {
-        memberRepository.findByNickNameAndDeletedAtNull(nickName)
+    private void validateNicknameDuplication(String nickname) throws DuplicateKeyException {
+        memberRepository.findByNicknameAndDeletedAtNull(nickname)
                 .ifPresent(m -> {
                     throw new DuplicateKeyException("이미 같은 닉네임이 존재합니다.");
                 });

--- a/MyohanMeeting/src/main/resources/import.sql
+++ b/MyohanMeeting/src/main/resources/import.sql
@@ -1,0 +1,15 @@
+
+-- 회원
+insert into member (`email`, `password`, `nickname`, `phone_number`, `certified`) values ('admin@admin.com', '$2a$08$lDnHPz7eUkSi6ao14Twuau08mzhWrL4kyZGGU5xfiGALO/Vxd5DOi', 'admin', '000-000-0000', 'CERTIFIED');
+insert into member (`email`, `password`, `nickname`, `phone_number`, `certified`) values ('user@user.com', '$2a$10$VSxtBNYSlET5xrTI/UL52OuOwGxc9DRBC8LuX097b4V2GGwdRC3/m', 'user', '000-000-0000', 'CERTIFIED');
+insert into member (`oauth_type`, `oauth_id`, `email`, `certified`) values ('KAKAOTALK', 'kakao', 'kakao@kakao.com', 'CERTIFIED');
+
+-- 권한
+insert into authority (`authority_name`) values ('ROLE_ADMIN');
+insert into authority (`authority_name`) values ('ROLE_USER');
+
+-- 회원별 권한
+insert into member_authority (`member_id`, `authority_id`) values (1, 1);
+insert into member_authority (`member_id`, `authority_id`) values (1, 2);
+insert into member_authority (`member_id`, `authority_id`) values (2, 2);
+insert into member_authority (`member_id`, `authority_id`) values (3, 2);


### PR DESCRIPTION
- #46 

**fix/ MemberAuthority 구현, PreAuthorize 설정**
- 컨트롤러에 PreAuthorize 설정
- 가입/탈퇴 시 Authority 관련 로직 추가
- import.sql 추가

**fix/ nickName->nickname으로 변경**
- nickname은 한 단어이므로 수정

**fix/ NPE 방어**
- NPE 방어 로직 추가
- 다른 Response DTO에도 적용 필요

**fix: 컨트롤러 수정**
- 문서화 어노테이션 추가
- 리프레시 엔드포인트 추가
- 리퀘스트 바디를 포함한 GET요청 쿼리 파라미터로 변경