### PR TITLE
Feat/cloud storage를 통한 Upload 구현

### DIFF
--- a/.github/workflows/build-with-docker.yml
+++ b/.github/workflows/build-with-docker.yml
@@ -34,16 +34,25 @@ jobs:
     
       - name: Checkout
         uses: actions/checkout@v3
-        
-      - run: mkdir ./MyohanMeeting/src/main/resources/config
-      - run: touch ./MyohanMeeting/src/main/resources/config/secret.yml
-      - run: echo "${{ secrets.DEV_SECRET_PROPERTIES }}" > ./MyohanMeeting/src/main/resources/config/secret.yml
-      - run: cat ./MyohanMeeting/src/main/resources/config/secret.yml
+
+      - name: Create Secret
+        run: |-
+          mkdir ./MyohanMeeting/src/main/resources/config
+          touch ./MyohanMeeting/src/main/resources/config/secret.yml
+          echo "${{ secrets.DEV_SECRET_PROPERTIES }}" > ./MyohanMeeting/src/main/resources/config/secret.yml
+          cat ./MyohanMeeting/src/main/resources/config/secret.yml
+
+      - name: Create Google Cloud Storage Key
+        run: |-
+          touch ./MyohanMeeting/src/main/resources/config/cloud-storage-key.json
+          echo "${{ secrets.GCS_SA_KEY }}" > ./MyohanMeeting/src/main/resources/config/cloud-storage-key.json
+          cat ./MyohanMeeting/src/main/resources/config/cloud-storage-key.json
 
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ out/
 .vscode/
 
 ### SECRET ###
+cloud-storage-key.json
 secret.yml
 
 ### Mac OS ###

--- a/MyohanMeeting/build.gradle
+++ b/MyohanMeeting/build.gradle
@@ -47,6 +47,10 @@ dependencies {
     // database
     runtimeOnly 'com.h2database:h2'
 
+    // Google Cloud Storage
+    implementation 'org.springframework.cloud:spring-cloud-gcp-starter:1.2.8.RELEASE'
+    implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.8.RELEASE'
+
     // p6spy
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 

--- a/MyohanMeeting/src/main/java/meet/myo/controller/UploadController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/UploadController.java
@@ -72,12 +72,12 @@ public class UploadController {
     @PostMapping("")
     public CommonResponseDto<Map<String, List<Long>>> uploadFilesV1(
             @Parameter(name = "files", description = "업로드하고자 하는 파일 배열입니다.")
-            @RequestParam MultipartFile[] files
+            @RequestParam MultipartFile[] files,
+            @RequestParam(value = "category") String fileCategory
     ) {
-        //TODO: 유효성 검증(파일 용량, 확장자, 10건 이상 업로드 불가 등)
         Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<Map<String, List<Long>>>builder()
-                .data(Map.of("uploadId", uploadService.uploadFiles(memberId, Arrays.stream(files).toList())))
+                .data(Map.of("uploadId", uploadService.uploadFiles(memberId, Arrays.stream(files).toList(), fileCategory)))
                 .build();
     }
 

--- a/MyohanMeeting/src/main/java/meet/myo/domain/FileCategory.java
+++ b/MyohanMeeting/src/main/java/meet/myo/domain/FileCategory.java
@@ -1,0 +1,5 @@
+package meet.myo.domain;
+
+public enum FileCategory {
+    CAT, PROFILE, SERVICE, NO_CATEGORY
+}

--- a/MyohanMeeting/src/main/java/meet/myo/domain/Upload.java
+++ b/MyohanMeeting/src/main/java/meet/myo/domain/Upload.java
@@ -25,9 +25,9 @@ public class Upload extends BaseAuditingListener {
     @Column(nullable = false)
     private String url;
 
-    @Size(max = 512)
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String path;
+    private FileCategory fileCategory;
 
     private String originName;
 
@@ -44,10 +44,10 @@ public class Upload extends BaseAuditingListener {
     private Long size;
 
     @Builder
-    Upload(String url, Member member, String path, String originName, String savedName, String type, String extension, Long size) {
+    Upload(String url, Member member, FileCategory fileCategory, String originName, String savedName, String type, String extension, Long size) {
         this.url = url;
         this.member = member;
-        this.path = path;
+        this.fileCategory = fileCategory;
         this.originName = originName;
         this.savedName = savedName;
         this.type = type;
@@ -64,8 +64,8 @@ public class Upload extends BaseAuditingListener {
         this.url = url;
     }
 
-    public void updatePath(String path) {
-        this.path = path;
+    public void updateFileCategory(FileCategory fileCategory) {
+        this.fileCategory = fileCategory;
     }
 
     public void updateOriginName(String originName) {

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberDirectCreateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberDirectCreateRequestDto.java
@@ -3,7 +3,6 @@ package meet.myo.dto.request.member;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
-import meet.myo.domain.Member;
 
 @Getter
 public class MemberDirectCreateRequestDto {
@@ -15,5 +14,5 @@ public class MemberDirectCreateRequestDto {
     private String password;
     private String nickname;
     private String phoneNumber;
-    private String profileImage;
+    private Long profileImageId;
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberOauthCreateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberOauthCreateRequestDto.java
@@ -10,4 +10,5 @@ public class MemberOauthCreateRequestDto {
     private String oauthId;
     private String email;
     private String nickname;
+    private Long profileImageId;
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/UploadResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/UploadResponseDto.java
@@ -1,7 +1,11 @@
 package meet.myo.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
 import meet.myo.domain.Upload;
 
+@Schema(name = "Upload")
+@Getter
 public class UploadResponseDto {
     private Long id;
     private String url;

--- a/MyohanMeeting/src/main/java/meet/myo/exception/RestExceptionHandler.java
+++ b/MyohanMeeting/src/main/java/meet/myo/exception/RestExceptionHandler.java
@@ -10,7 +10,6 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.ErrorResponse;
 import meet.myo.dto.response.ErrorResponseDto;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
@@ -75,9 +74,12 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(DuplicateKeyException.class)
-    protected ResponseEntity<ErrorResponse> handleDuplicateKeyException(DuplicateKeyException ex) {
-        ErrorResponse errorResponse = ErrorResponse.builder(ex, HttpStatus.CONFLICT, "Duplicate resource")
-                .build();
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    protected ResponseEntity<ErrorResponseDto> handleDuplicateKeyException(DuplicateKeyException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                ErrorResponseDto.builder()
+                        .status(HttpStatus.CONFLICT.toString())
+                        .message("Duplicate resource")
+                        .debugMessage(ex.getMessage())
+                        .build());
     }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/service/CloudStorageService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/CloudStorageService.java
@@ -1,0 +1,67 @@
+package meet.myo.service;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+public class CloudStorageService {
+
+    private final String projectId;
+
+    private final String bucketName;
+
+    public CloudStorageService(
+            @Value("${spring.cloud.gcp.storage.project-id}") String projectId,
+            @Value("${spring.cloud.gcp.storage.bucket}") String bucketName
+    ) {
+        this.projectId = projectId;
+        this.bucketName = bucketName;
+    }
+
+    /**
+     * 버킷에 파일 업로드
+     */
+    public void doUpload(MultipartFile file, String objectName) throws IOException {
+        Storage storage = StorageOptions.newBuilder().setProjectId(this.projectId).build().getService();
+        BlobId blobId = BlobId.of(this.bucketName, objectName);
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId)
+                .setContentType(file.getContentType())
+                .build();
+
+        storage.create(blobInfo, file.getBytes());
+    }
+
+    /**
+     * 버킷에서 파일 삭제
+     */
+    public void doDelete(String url) {
+        String objectName = getObjectName(url);
+        Storage storage = StorageOptions.newBuilder().setProjectId(this.projectId).build().getService();
+        if (storage.get(bucketName, objectName) == null) {
+            throw new IllegalArgumentException("URL에 해당하는 파일을 찾을 수 없습니다.");
+        }
+
+        storage.delete(bucketName, objectName);
+    }
+
+    /**
+     * 버킷 객체명으로 파일 URL 생성
+     */
+    public String getUrl(String filePath) {
+        return "https://storage.googleapis.com/" + this.bucketName + "/" + filePath;
+    }
+
+    /**
+     * 파일 URL로부터 버킷 객체명 추출
+     */
+    private String getObjectName(String url) {
+        return url.split(this.bucketName + "/")[1];
+    }
+}


### PR DESCRIPTION
### fix: gitignore 위치 수정 
- gitignore 위치 루트로 수정
- gitignore에 클라우드 스토리지 키 파일 추가

### feat: cloud storage 업로드 구현 
- GCS 의존성 추가
- GCS 업로드 서비스 별도 클래스로 분리, 업로드 및 삭제 구현
- UploadService 주석 추가 및 코드 보강
- Upload 엔티티 path -> file category로 변경, 타입 Enum으로 변경
- 회원가입 시 url이 아닌 upload id로 프로필 이미지 입력하도록 변경
- UploadResponseDto Getter 누락 수정, Schema 정보 추가

### feat: github action 수정 
- cloud storage 관련 스텝 추가
- 각 스텝 name 추가

### 그 외
- CONFLICT 응답 DTO 다른 메서드들과 일치하게 수정