### PR TITLE
fix/인증 관련 오류 및 작동 수정

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/config/SecurityUtil.java
+++ b/MyohanMeeting/src/main/java/meet/myo/config/SecurityUtil.java
@@ -3,7 +3,9 @@ package meet.myo.config;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import meet.myo.domain.authority.CustomOAuth2User;
 import meet.myo.domain.authority.CustomUser;
+import meet.myo.exception.NotAuthenticatedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -14,9 +16,8 @@ import java.util.Optional;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SecurityUtil {
 
-    private static final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
     public static Optional<String> getCurrentUserName() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null) {
             log.debug("Security Context에 관련 정보가 없습니다.");
@@ -35,6 +36,7 @@ public class SecurityUtil {
     }
 
     public static Optional<Long> getCurrentUserPK() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null) {
             log.debug("Security Context에 관련 정보가 없습니다.");
@@ -45,8 +47,11 @@ public class SecurityUtil {
         if (authentication.getPrincipal() instanceof CustomUser) {
             CustomUser user = (CustomUser) authentication.getPrincipal();
             userPK = user.getUserPK();
-        } else if (authentication.getPrincipal() instanceof String) {
-            userPK = null;
+        } else if (authentication.getPrincipal() instanceof CustomOAuth2User) {
+            CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
+            userPK = user.getUserPK();
+        } else {
+            throw new NotAuthenticatedException("로그인 정보가 존재하지 않습니다.");
         }
 
         return Optional.ofNullable(userPK);

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
@@ -33,7 +33,6 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/adoption/notices")
-@PreAuthorize("hasAnyRole('ROLE_USER')")
 public class AdoptNoticeController {
 
     private final AdoptNoticeService adoptNoticeService;
@@ -140,6 +139,7 @@ public class AdoptNoticeController {
      */
     @Operation(summary = "내가 올린 분양공고 목록조회", description = "자신이 업로드한 분양 공고 목록을 조회합니다.", operationId = "getMyNoticeList")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @GetMapping("/my")
     public CommonResponseDto<List<AdoptNoticeSummaryResponseDto>> getMyNoticeListV1(
             /**
@@ -203,6 +203,7 @@ public class AdoptNoticeController {
   }
 }
 """)})) @ApiResponseCommon @ApiResponseSignin
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @SecurityRequirement(name = "JWT")
     @PostMapping("")
     public CommonResponseDto<Map<String, Long>> createNoticeV1(@Validated @RequestBody final AdoptNoticeRequestDto dto) {
@@ -217,6 +218,7 @@ public class AdoptNoticeController {
      */
     @Operation(summary = "분양공고 상태 업데이트", description = "분양공고의 상태를 업데이트합니다.", operationId = "updateNoticeStatus")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @SecurityRequirement(name = "JWT")
     @PatchMapping("/{noticeId}/status")
     public CommonResponseDto<AdoptNoticeResponseDto> updateNoticeStatusV1(
@@ -237,6 +239,7 @@ public class AdoptNoticeController {
     @Operation(summary = "분양공고 수정", description = "분양공고의 내용을 수정합니다.", operationId = "updateNotice")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @PatchMapping("/{noticeId}")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @SecurityRequirement(name = "JWT")
     public CommonResponseDto<AdoptNoticeResponseDto> updateNoticeV1(
             @Parameter(name = "noticeId", description = "수정하고자 하는 공고의 id입니다.")
@@ -265,6 +268,7 @@ public class AdoptNoticeController {
   }
 }
 """)})) @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @SecurityRequirement(name = "JWT")
     @DeleteMapping("/{noticeId}")
     public CommonResponseDto<Map<String, Long>> deleteNoticeV1(

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AuthController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AuthController.java
@@ -1,7 +1,6 @@
 package meet.myo.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/MyohanMeeting/src/main/java/meet/myo/jwt/TokenProvider.java
+++ b/MyohanMeeting/src/main/java/meet/myo/jwt/TokenProvider.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import meet.myo.config.SecurityUtil;
+import meet.myo.domain.authority.CustomOAuth2User;
 import meet.myo.domain.authority.CustomUser;
 import meet.myo.service.CustomPrincipalDetailService;
 import org.springframework.beans.factory.InitializingBean;
@@ -14,6 +15,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
@@ -22,6 +24,9 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
 
+/**
+ * 토큰을 생성, 처리하는 클래스
+ */
 @Component
 public class TokenProvider implements InitializingBean {
 
@@ -37,7 +42,6 @@ public class TokenProvider implements InitializingBean {
 
     private final CustomPrincipalDetailService customPrincipalDetailService;
 
-    // yml 파일에서 jwt의 access, refresh를 들고옴
     public TokenProvider(
             @Value("${jwt.access-token-validity-time}") long accessTokenValidityTime,
             @Value("${jwt.refresh-token-validity-time}") long refreshTokenValidityTime,
@@ -52,22 +56,29 @@ public class TokenProvider implements InitializingBean {
         this.customPrincipalDetailService = customPrincipalDetailService;
     }
 
-    // BASE64로 Decode하는 코드
     @Override
     public void afterPropertiesSet() {
         this.accessKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(accessSecret));
         this.refreshKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(refreshSecret));
     }
 
+    /**
+     * authentication 객체로 액세스 토큰 생성
+     */
     public String getAccessToken(Authentication authentication) {
         return createToken(authentication, accessTokenValidityTime, accessKey, true);
     }
 
+    /**
+     * authentication 객체로 리프레시 토큰 생성
+     */
     public String getRefreshToken(Authentication authentication) {
         return createToken(authentication, refreshTokenValidityTime, refreshKey, false);
     }
 
-    // 인증 부분
+    /**
+     * 액세스/리프레시 토큰으로부터 authentication 객체 생성
+     */
     public Authentication getAuthentication(String token, boolean isAccessToken) {
         Key key = isAccessToken ? accessKey : refreshKey;
         Claims claims = Jwts
@@ -80,14 +91,17 @@ public class TokenProvider implements InitializingBean {
         UserDetails principal;
         Collection<? extends GrantedAuthority> authorities;
 
-        if (claims.containsKey(AUTH_CLAIM_NAME) && claims.containsKey("memberId")) { // 액세스 토큰일 경우(클레임 존재) DB접근 없이 클레임에서 찾음
+
+        // 토큰에 클레임 존재할 경우 DB 접근 없이 클레임에서 정보를 찾음
+        if (claims.containsKey(AUTH_CLAIM_NAME) && claims.containsKey("memberId")) {
             authorities = Arrays.stream(claims.get(AUTH_CLAIM_NAME).toString().split(","))
                     .map(SimpleGrantedAuthority::new)
                     .collect(Collectors.toList());
 
             principal = new CustomUser(claims.getSubject(), "", authorities, Long.valueOf(claims.get("memberId").toString()));
 
-        } else { // ref 토큰일 경우(클레임 없음) DB접근 후 찾음
+        // 토큰에 클레임 존재하지 않을 경우 DB 접근 후 정보를 찾음
+        } else {
             principal = customPrincipalDetailService.loadUserByUsername(claims.getSubject());
             authorities = principal.getAuthorities();
         }
@@ -128,10 +142,17 @@ public class TokenProvider implements InitializingBean {
         JwtBuilder builder = Jwts.builder()
                 .setSubject(authentication.getName());
 
-        // 이미 클레임이 존재하면 refreshtoken 만드는 부분
         if (claimIncluded) {
+            Long userPK = null;
+
+            if (authentication instanceof UsernamePasswordAuthenticationToken) {
+                userPK = ((CustomUser)authentication.getPrincipal()).getUserPK();
+            } else if (authentication instanceof OAuth2AuthenticationToken) {
+                userPK = ((CustomOAuth2User)authentication.getPrincipal()).getUserPK();
+            }
+
             builder.claim(AUTH_CLAIM_NAME, authorities)
-                    .claim("memberId", SecurityUtil.getCurrentUserPK().orElse(null));
+                    .claim("memberId", userPK);
         }
 
 

--- a/MyohanMeeting/src/main/java/meet/myo/service/AuthService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/AuthService.java
@@ -21,12 +21,13 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.stereotype.Service;
 
 /**
- * Controller 단에서 직접 호출하는 서비스
+ * 인증 서비스
  *
- * TokenProvider: JWT 생성
- * AuthenticationManagerBuilder: 폼로그인 시 authenticate() -> loadUserByName() 호출, 비밀번호를 대조
- * CustomPrincipalDetailService: 폼로그인 시 필요한 User + Oauth 로그인 시 필요한 OAuth2DefaultUser 객체 획득
+ * TokenProvider: 토큰에 관련된 작업(생성, 파싱) 위임
+ * AuthenticationManagerBuilder: UsernamePasswordAuthenticationToken으로 authenticate() -> loadUserByUsername() 호출, 비밀번호를 대조
+ * CustomPrincipalDetailService: loadUserByUsername(), loadUserByOauth() 갖고 있는 클래스
  */
+
 @Service
 @Transactional
 @RequiredArgsConstructor

--- a/MyohanMeeting/src/main/java/meet/myo/service/CustomPrincipalDetailService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/CustomPrincipalDetailService.java
@@ -28,28 +28,37 @@ public class CustomPrincipalDetailService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
 
-    //이메일로 사용자 정보 조회
+    /**
+     * username(email)로 Authentication 객체 조회
+     * AuthenticationManagerBuilder의 authenticate() 실행 시 호출됨
+     */
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        log.trace("loadUserByUsername called");
         return memberRepository.findByEmailAndDeletedAtNull(email)
                 .map(this::createUser)
                 .orElseThrow(() -> new UsernameNotFoundException("이메일이 \"" + email + "\"인 회원을 찾을 수 없습니다."));
     }
 
-    // Oauth 사용자 조회
+    /**
+     * OAuth 정보로 Authentication 객체 조회
+     * loadByUsername과는 달리 직접 호출해야 함.
+     */
     public CustomOAuth2User loadUserByOauth(String oauthType, String oauthId) {
         return memberRepository.findByOauthOauthTypeAndOauthOauthIdAndDeletedAtNull(OauthType.valueOf(oauthType), oauthId)
                 .map(this::createOauthUser)
                 .orElseThrow(NotFoundException::new);
     }
 
-    // CustomUser로 유저 생성
+
     private CustomUser createUser(Member member) {
         List<GrantedAuthority> grantedAuthorities = member.getMemberAuthorities()
                 .stream().map(authority -> new SimpleGrantedAuthority(authority.toAuthority().getAuthorityName()))
                 .collect(Collectors.toList());
-        return new CustomUser(member.getEmail(), member.getPassword(), grantedAuthorities, member.getId());
+        return new CustomUser(
+                member.getEmail(),
+                member.getPassword() != null ? member.getPassword() : "", // OAuth2 가입으로 비밀번호 없는 경우 blank 처리
+                grantedAuthorities,
+                member.getId());
     }
 
     private CustomOAuth2User createOauthUser(Member member) {

--- a/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
@@ -180,7 +180,9 @@ public class MemberService {
     public void deleteOauth(Long memberId) {
         Member member = memberRepository.findByIdAndDeletedAtNull(memberId)
                 .orElseThrow(() -> new NotFoundException("id에 해당하는 회원을 찾을 수 없습니다."));
-
+        if (member.getPassword() == null) {
+            throw new IllegalArgumentException("SNS 로그인 정보를 삭제하려면 먼저 비밀번호를 설정해야 합니다.");
+        }
         member.updateOauth(null);
     }
 
@@ -194,7 +196,8 @@ public class MemberService {
                 .orElseThrow(() -> new NotFoundException("id에 해당하는 회원을 찾을 수 없습니다."));
 
         String currentPassword = dto.getCurrentPassword();
-        if (!passwordEncoder.matches(currentPassword, member.getPassword())) {
+        // 현재 설정된 비밀번호가 없다면 비밀번호를 검증하지 않음. 있다면 검증.
+        if (member.getPassword() != null && !passwordEncoder.matches(currentPassword, member.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
@@ -212,7 +215,6 @@ public class MemberService {
 
         member.updateNickname(dto.getNickname());
         member.updatePhoneNumber(dto.getPhoneNumber());
-
         return MemberUpdateResponseDto.fromEntity(member);
     }
 


### PR DESCRIPTION
### AdoptNotice 조회 시 인증 필요없도록 수정
- SecurityConfig에 예외로 추가, Controller 단에서의 PreAuthorize 어노테이션도 변경

### SecurityUtil 메서드 디버그
- 기존에는 SecurityUtil의 final 멤버변수로 SecurityContext의 authentication 객체가 선언되어 있었음
- a회원으로 로그인 후 b회원 정보로 다시 로그인 엔드포인트를 호출할 경우, SecurityUtil이 갱신된 b회원의 user context를 정상적으로 받아오지 못함
- 호출 시마다 새롭게 SecurityContext가 초기화될 필요가 있어 SecurityUtil 내의 SecurityContext를 멤버변수가 아닌 지역변수로 수정

### 직접가입, SNS 가입 여부에 따라 토큰 처리 분기 추가
- TokenProvider.getAuthentication(): refreshToken으로부터 authentication 객체를 생성할 경우 회원가입 종류에 상관없이 Principal 객체를 CustomUser로 일괄 생성하는데, 비밀번호가 없는 회원(Oauth2 가입)의 경우 getPassword() 메서드가 null을 반환하므로 그 경우 credential에 빈 스트링을 입력하도록 수정
- TokenProvider.createToken(): authentication 객체에서 userPK를 추출하기 전 타입체크 및 형변환 과정 추가

### 그 외
- 주석 보강