### PR TITLE
Fix/adopt notice 관련 비즈니스 로직 수정

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/domain/adopt/notice/AdoptNotice.java
+++ b/MyohanMeeting/src/main/java/meet/myo/domain/adopt/notice/AdoptNotice.java
@@ -41,7 +41,7 @@ public class AdoptNotice extends BaseAuditingListener {
     private String content;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "upload_id")
+    @JoinColumn(name = "thumbnail_id")
     private Upload thumbnail;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "adoptNotice")
@@ -53,18 +53,20 @@ public class AdoptNotice extends BaseAuditingListener {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "adoptNotice")
     private List<AdoptApplication> applicationList;
 
-    private Integer applicationCount;
+    private Integer applicationCount = 0;
 
-    private Integer commentCount;
+    private Integer commentCount = 0;
 
     // 접수중 상태로 초기화
     @Enumerated(EnumType.STRING)
     private AdoptNoticeStatus noticeStatus = AdoptNoticeStatus.ACCEPTING;
 
     @Builder
-    AdoptNotice(Cat cat, Member member, String title, String content) {
-        this.cat = cat;
+    AdoptNotice(Member member, Cat cat, Shelter shelter, Upload thumbnail, String title, String content) {
         this.member = member;
+        this.cat = cat;
+        this.shelter = shelter;
+        this.thumbnail = thumbnail;
         this.title = title;
         this.content = content;
     }
@@ -85,13 +87,6 @@ public class AdoptNotice extends BaseAuditingListener {
         this.noticeStatus = status;
     }
 
-    /**
-     * TODO: updateCat
-     */
-    public void updateCat(Cat cat) { this.cat = cat; }
-
-    public void updateShelter(Shelter shelter) { this.shelter = shelter; }
-
     public void addApplication() {
         applicationCount ++;
     }
@@ -108,4 +103,10 @@ public class AdoptNotice extends BaseAuditingListener {
         commentCount --;
     }
 
+    public void delete() {
+        catPictures.forEach(CatPicture::delete);
+        commentList.forEach(AdoptNoticeComment::delete);
+        applicationList.forEach(AdoptApplication::delete);
+        super.delete();
+    }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/domain/adopt/notice/cat/CatPicture.java
+++ b/MyohanMeeting/src/main/java/meet/myo/domain/adopt/notice/cat/CatPicture.java
@@ -33,6 +33,7 @@ public class CatPicture extends BaseAuditingListener {
         return this.upload.getUrl();
     }
 
+    public void delete() { super.delete(); }
     public static CatPicture createCatPicture(AdoptNotice notice, Upload upload) {
         CatPicture catPicture = new CatPicture();
         catPicture.adoptNotice = notice;

--- a/MyohanMeeting/src/main/java/meet/myo/repository/AdoptNoticeRepository.java
+++ b/MyohanMeeting/src/main/java/meet/myo/repository/AdoptNoticeRepository.java
@@ -12,4 +12,6 @@ import java.util.Optional;
 public interface AdoptNoticeRepository extends JpaRepository<AdoptNotice, Long> {
     Optional<AdoptNotice> findByIdAndDeletedAtNull(Long noticeId);
     Page<AdoptNotice> findByMemberIdAndDeletedAtNull(Pageable pageable, Long memberId);
+
+    Page<AdoptNotice> findByDeletedAtNull(Pageable pageable);
 }


### PR DESCRIPTION
### fix: AdoptNotice 엔티티 수정 
- AdoptNotice 엔티티 빌더에 thumbnail, shelter 추가
- AdoptNotice 엔티티 내의 임베디드 타입에 대한 updateXXX 메서드 삭제
- AdoptNotice 엔티티에 soft delete 메서드 구현
- AdoptNotice 엔티티에 썸네일 관련 컬럼명 수정

### fix: AdoptNotice 관련 비즈니스 로직 수정 
- Repository에 AdoptNotice 다수조회 메서드 추가
- AdoptNotice 일부 soft delete 제외 처리되어있지 않은 부분 수정