### PR TITLE
Fix/repository단 오류 수정 및 코드 보강

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/repository/AdoptApplicationRepository.java
+++ b/MyohanMeeting/src/main/java/meet/myo/repository/AdoptApplicationRepository.java
@@ -4,15 +4,18 @@ package meet.myo.repository;
 import meet.myo.domain.adopt.application.AdoptApplication;
 import meet.myo.domain.adopt.notice.AdoptNotice;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface AdoptApplicationRepository extends JpaRepository<AdoptApplication, Long> {
 
-    Page<AdoptApplication> findByAdoptNoticeIdAndDeletedAtNull(AdoptNotice adoptNotice, org.springframework.data.domain.Pageable pageable);
+    Page<AdoptApplication> findByAdoptNoticeIdAndDeletedAtNull(Long adoptNoticeId, Pageable pageable);
 
-    Page<AdoptApplication> findByMemberIdAndDeletedAtNull(Long memberId, org.springframework.data.domain.Pageable pageable);
+    Page<AdoptApplication> findByMemberIdAndDeletedAtNull(Long memberId, Pageable pageable);
 
-
+    Optional<AdoptApplication> findByIdAndDeletedAtNull(Long applicationId);
 }

--- a/MyohanMeeting/src/main/java/meet/myo/repository/FavoriteRepository.java
+++ b/MyohanMeeting/src/main/java/meet/myo/repository/FavoriteRepository.java
@@ -11,5 +11,6 @@ import java.util.Optional;
 @Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     Optional<Favorite> findByIdAndDeletedAtNull(Long id);
-    Page<Favorite> findByIdAndDeletedAtNull(Long memberId, Pageable pageable);
+    Optional<Favorite> findByMemberIdAndAdoptNoticeIdAndDeletedAtNull(Long memberId, Long adoptNoticeId);
+    Page<Favorite> findByMemberIdAndDeletedAtNull(Long memberId, Pageable pageable);
 }

--- a/MyohanMeeting/src/main/java/meet/myo/repository/UploadRepository.java
+++ b/MyohanMeeting/src/main/java/meet/myo/repository/UploadRepository.java
@@ -4,11 +4,13 @@ import meet.myo.domain.Upload;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UploadRepository extends JpaRepository<Upload, Long> {
 
     Optional<Upload> findByIdAndDeletedAtNull(Long uploadId);
+    List<Upload> findByIdInAndDeletedAtNull(List<Long> uploadIds);
 
 }

--- a/MyohanMeeting/src/main/java/meet/myo/service/AdoptApplicationService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/AdoptApplicationService.java
@@ -40,7 +40,7 @@ public class AdoptApplicationService {
             throw new AccessDeniedException("작성자만 분양신청 목록을 열람할 수 있습니다.");
         }
 
-        Page<AdoptApplication> adoptApplications = adoptApplicationRepository.findByAdoptNoticeIdAndDeletedAtNull(adoptNotice, pageable);
+        Page<AdoptApplication> adoptApplications = adoptApplicationRepository.findByAdoptNoticeIdAndDeletedAtNull(adoptNotice.getId(), pageable);
 
         return adoptApplications.getContent().stream()
                 .map(AdoptApplicationResponseDto::fromEntity)
@@ -66,7 +66,7 @@ public class AdoptApplicationService {
      */
     @Transactional(readOnly = true)
     public AdoptApplicationResponseDto getAdoptApplication(Long applicationId) {
-        AdoptApplication adoptApplication = adoptApplicationRepository.findById(applicationId)
+        AdoptApplication adoptApplication = adoptApplicationRepository.findByIdAndDeletedAtNull(applicationId)
                 .orElseThrow(() -> new NotFoundException("해당하는 분양신청이 존재하지 않습니다."));
         return AdoptApplicationResponseDto.fromEntity(adoptApplication);
     }
@@ -77,10 +77,10 @@ public class AdoptApplicationService {
      * 작성
      */
     public Long createAdoptApplication(Long memberId, AdoptApplicationRequestDto dto) {
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdAndDeletedAtNull(memberId)
                 .orElseThrow(() -> new NotFoundException("Member not found"));
 
-        AdoptNotice adoptNotice = adoptNoticeRepository.findById(dto.getNoticeId())
+        AdoptNotice adoptNotice = adoptNoticeRepository.findByIdAndDeletedAtNull(dto.getNoticeId())
                 .orElseThrow(() -> new NotFoundException("Adopt notice not found"));
 
         Applicant applicant = Applicant.builder()
@@ -123,7 +123,7 @@ public class AdoptApplicationService {
      * 수정
      */
     public AdoptApplicationResponseDto updateAdoptApplication(Long memberId, Long applicationId, AdoptApplicationRequestDto dto) {
-        AdoptApplication adoptApplication = adoptApplicationRepository.findById(applicationId)
+        AdoptApplication adoptApplication = adoptApplicationRepository.findByIdAndDeletedAtNull(applicationId)
                 .orElseThrow(() -> new NotFoundException("해당하는 분양신청이 존재하지 않습니다."));
 
         if (!adoptApplication.getMember().getId().equals(memberId)) {
@@ -158,7 +158,6 @@ public class AdoptApplicationService {
             adoptApplication.updateContent(dto.getContent());
         }
 
-        adoptApplicationRepository.save(adoptApplication);
         return AdoptApplicationResponseDto.fromEntity(adoptApplication);
     }
 
@@ -168,7 +167,7 @@ public class AdoptApplicationService {
      * 삭제
      */
     public Long deleteAdoptApplication(Long memberId, Long applicationId) {
-        AdoptApplication adoptApplication = adoptApplicationRepository.findById(applicationId)
+        AdoptApplication adoptApplication = adoptApplicationRepository.findByIdAndDeletedAtNull(applicationId)
                 .orElseThrow(() -> new NotFoundException("해당하는 분양신청이 존재하지 않습니다."));
 
         if (!adoptApplication.getMember().getId().equals(memberId)) {

--- a/MyohanMeeting/src/main/java/meet/myo/service/UploadService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/UploadService.java
@@ -103,7 +103,7 @@ public class UploadService {
      * 파일 삭제
      */
     public List<Long> deleteFiles(Long memberId, List<Long> uploadIdList) {
-        List<Upload> uploadList = uploadRepository.findAllById(uploadIdList);
+        List<Upload> uploadList = uploadRepository.findByIdInAndDeletedAtNull(uploadIdList);
         Member member = memberRepository.findByIdAndDeletedAtNull(memberId)
                 .orElseThrow(() -> new NotFoundException("id에 해당하는 회원을 찾을 수 없습니다."));
 


### PR DESCRIPTION
### fix: AdoptApplication 레포지토리, 비즈니스 로직 수정 
- findByAdoptNoticeIdAndDeletedAtNull 메서드의 잘못된 인자 수정
- Pageable import문 추가
- 분양신청 상세조회 메서드 추가

### fix: 최애친구 비즈니스로직 수정 
- 특정 회원의 최애친구 조회 메서드 수정
- 이미 등록한 최애친구인지 확인하는 로직 추가

### fix: Upload 관련 비즈니스 로직 수정 
- 다수 id로 조회하는 메서드 추가(where in query)