### PR TITLE
Fix/기존회원 oauth 정보 변경 로직 수정

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
@@ -19,13 +19,12 @@ import meet.myo.dto.response.*;
 import meet.myo.dto.response.member.EmailUpdateResponseDto;
 import meet.myo.dto.response.member.MemberResponseDto;
 import meet.myo.dto.response.member.MemberUpdateResponseDto;
-import meet.myo.dto.response.member.OauthUpdateResponseDto;
+import meet.myo.dto.response.member.OauthRegisterResponseDto;
 import meet.myo.exception.NotAuthenticatedException;
 import meet.myo.service.MemberService;
 import meet.myo.springdoc.annotations.ApiResponseCommon;
 import meet.myo.springdoc.annotations.ApiResponseSignin;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -216,35 +215,35 @@ public class MemberController {
     }
 
     /**
-     * SNS 로그인 정보 수정
+     * SNS 연결
      */
-    @Operation(summary = "SNS 로그인 정보 수정",
-            description = "SNS 로그인 정보를 수정하거나, SNS 로그인을 설정한 적 없는 직접 가입 회원의 경우 SNS 로그인 정보를 새롭게 연결합니다.",
-            operationId = "updateOauth")
     @Tag(name = "2. Member", description = "회원 관련 기능")
+    @Operation(summary = "SNS 로그인 연결",
+            description = "로그인에 사용할 SNS를 새롭게 연결합니다. 이미 SNS 로그인 정보가 등록되어 있을 경우 먼저 해제가 필요합니다.",
+            operationId = "registerOauth")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
-    @PutMapping("/oauth")
-    public CommonResponseDto<OauthUpdateResponseDto> updateOauthV1(@Validated @RequestBody final OauthUpdateRequestDto dto) {
+    @PostMapping("/oauthInfo")
+    public CommonResponseDto<OauthRegisterResponseDto> registerOauthV1(@Valid @RequestBody final OauthRegisterRequestDto dto) {
         Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
-        return CommonResponseDto.<OauthUpdateResponseDto>builder()
-                .data(memberService.updateOauth(memberId, dto))
+        return CommonResponseDto.<OauthRegisterResponseDto>builder()
+                .data(memberService.registerOauth(memberId, dto))
                 .build();
     }
 
     /**
      * SNS 로그인 정보 삭제
      */
-    @Operation(summary = "SNS 로그인 정보 삭제", description = "연결된 SNS 로그인 정보를 삭제합니다.", operationId = "removeOauth")
     @Tag(name = "2. Member", description = "회원 관련 기능")
+    @Operation(summary = "SNS 연결 해제", description = "연결된 SNS 로그인 정보를 해제합니다. 비밀번호를 등록한 회원만 해제가 가능합니다.", operationId = "removeOauth")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @SecurityRequirement(name = "JWT")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
-    @DeleteMapping("/oauth")
-    public CommonResponseDto removeOauthV1() {
+    @DeleteMapping("/oauthInfo")
+    public CommonResponseDto removeOauthV1(@Valid @RequestBody OauthDeleteRequestDto dto) {
         Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
-        memberService.deleteOauth(memberId);
+        memberService.deleteOauth(memberId, dto);
         return CommonResponseDto.builder().build();
     }
 

--- a/MyohanMeeting/src/main/java/meet/myo/domain/Oauth.java
+++ b/MyohanMeeting/src/main/java/meet/myo/domain/Oauth.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/OauthDeleteRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/OauthDeleteRequestDto.java
@@ -1,0 +1,10 @@
+package meet.myo.dto.request.member;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class OauthDeleteRequestDto {
+    @NotNull(message = "{validation.NotNull}")
+    private String password;
+}

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/OauthRegisterRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/OauthRegisterRequestDto.java
@@ -7,7 +7,7 @@ import meet.myo.domain.OauthType;
 import meet.myo.util.validation.enums.EnumValid;
 
 @Getter
-public class OauthUpdateRequestDto {
+public class OauthRegisterRequestDto {
 
     @Schema(type = "string", allowableValues = {"KAKAOTALK"}, example = "KAKAOTALK")
     @NotNull(message = "{validation.NotNull}")

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/ErrorResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/ErrorResponseDto.java
@@ -3,7 +3,6 @@ package meet.myo.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/member/OauthRegisterResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/member/OauthRegisterResponseDto.java
@@ -4,11 +4,11 @@ import lombok.Getter;
 import meet.myo.domain.Member;
 
 @Getter
-public class OauthUpdateResponseDto {
+public class OauthRegisterResponseDto {
     private String oauthType;
 
-    public static OauthUpdateResponseDto fromEntity(Member member) {
-        OauthUpdateResponseDto dto = new OauthUpdateResponseDto();
+    public static OauthRegisterResponseDto fromEntity(Member member) {
+        OauthRegisterResponseDto dto = new OauthRegisterResponseDto();
         dto.oauthType = member.getOauth().getOauthType().toString();
         return dto;
     }

--- a/MyohanMeeting/src/main/java/meet/myo/repository/MemberRepository.java
+++ b/MyohanMeeting/src/main/java/meet/myo/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package meet.myo.repository;
 import meet.myo.domain.Member;
 import meet.myo.domain.OauthType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,11 +13,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByIdAndDeletedAtNull(Long memberId);
 
-    // findOneBy
     Optional<Member> findByEmailAndDeletedAtNull(String email);
-    Optional<Member> findByOauthOauthTypeAndOauthOauthIdAndDeletedAtNull(OauthType oauthType, String oauthId);
 
-    // findOneBy
     Optional<Member> findByNicknameAndDeletedAtNull(String nickname);
 
+    @Query("select m from Member m " +
+            "where m.oauth.oauthType = :oauthType " +
+            "and m.oauth.oauthId = :oauthId " +
+            "and m.deletedAt is NULL")
+    Optional<Member> findByOauth(OauthType oauthType, String oauthId);
 }

--- a/MyohanMeeting/src/main/java/meet/myo/service/CustomPrincipalDetailService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/CustomPrincipalDetailService.java
@@ -44,7 +44,7 @@ public class CustomPrincipalDetailService implements UserDetailsService {
      * loadByUsername과는 달리 직접 호출해야 함.
      */
     public CustomOAuth2User loadUserByOauth(String oauthType, String oauthId) {
-        return memberRepository.findByOauthOauthTypeAndOauthOauthIdAndDeletedAtNull(OauthType.valueOf(oauthType), oauthId)
+        return memberRepository.findByOauth(OauthType.valueOf(oauthType), oauthId)
                 .map(this::createOauthUser)
                 .orElseThrow(NotFoundException::new);
     }

--- a/MyohanMeeting/src/main/resources/application-local.yml
+++ b/MyohanMeeting/src/main/resources/application-local.yml
@@ -1,6 +1,7 @@
 spring:
   config:
-    import: classpath:./config/secret.yml
+    import:
+      - classpath:./config/secret.yml
 
   h2:
     console:


### PR DESCRIPTION
### fix: 기존회원 Oauth정보 변경 로직 수정 
- 기존 회원의 Oauth 정보 변경은 기존정보 삭제+신규등록만 가능하도록 변경
- 실제 서비스상에서는 연결/해제 등으로 표시
- Oauth 정보는 유저 식별자이면서 동시에 Credential 역할을 하기 때문에 기존 정보가 있는 상태에서 새 정보로 수정하는 것이 안정적이지 않다고 판단함
- 회원가입 및 정보변경 Oauth 중복체크 로직 추가
- 패스워드 등록한 회원만 Oauth 삭제 가능하도록 수정
- Oauth 정보로 멤버 확인하는 레포지토리 코드 리팩터링

### refactor: 불필요한 import 삭제 등 
- 불필요한 import문 삭제
- application.yml import 배열 형식으로 통일