### PR TITLE
Fix/validation 오류 수정 등

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptApplicationController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptApplicationController.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 @Tag(name = "4. Adopt Application", description = "분양신청 관련 기능")
-@SecurityRequirement(name = "JWT")
+@SecurityRequirement(name = "Authorization")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/adoption/applications")

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeCommentController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeCommentController.java
@@ -66,7 +66,7 @@ public class AdoptNoticeCommentController {
   }
 }
 """)})) @ApiResponseCommon @ApiResponseResource @ApiResponseSignin
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PostMapping("/comments")
     public CommonResponseDto<Map<String, Long>> createNoticeCommentV1(
             @Valid @RequestBody final AdoptNoticeCommentCreateRequestDto dto
@@ -83,7 +83,7 @@ public class AdoptNoticeCommentController {
     @Operation(summary = "분양공고 댓글 수정", description = "분양공고 댓글의 내용을 수정합니다.", operationId = "updateNoticeCommentV1")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @PutMapping("/comments/{noticeCommentId}")
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     public CommonResponseDto<AdoptNoticeCommentResponseDto> updateNoticeCommentV1(
             @Parameter(name = "noticeCommentId", description = "수정하고자 하는 댓글의 id입니다.")
             @PathVariable(name = "noticeCommentId") Long noticeCommentId,
@@ -111,7 +111,7 @@ public class AdoptNoticeCommentController {
   }
 }
 """)})) @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @DeleteMapping("/comments/{noticeCommentId}")
     public CommonResponseDto<Map<String, Long>> deleteNoticeCommentV1(
             @Parameter(name = "noticeCommentId", description = "삭제하고자 하는 댓글의 id입니다.")

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import meet.myo.config.SecurityUtil;
+import meet.myo.domain.adopt.notice.AdoptNoticeStatus;
+import meet.myo.domain.adopt.notice.City;
 import meet.myo.dto.request.adopt.AdoptNoticeCreateRequestDto;
 import meet.myo.dto.request.adopt.AdoptNoticeUpdateRequestDto;
 import meet.myo.dto.response.adopt.AdoptNoticeResponseDto;
@@ -21,6 +23,7 @@ import meet.myo.exception.NotAuthenticatedException;
 import meet.myo.search.AdoptNoticeSearch;
 import meet.myo.service.AdoptNoticeService;
 import meet.myo.springdoc.annotations.*;
+import meet.myo.util.validation.enums.EnumValid;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -91,7 +94,7 @@ public class AdoptNoticeController {
                     allowableValues = {"SEOUL", "SEJONG", "BUSAN", "DAEGU", "INCHEON", "GWANGJU", "ULSAN", "DAEJEON",
                             "GYEONGGI", "GANGWON", "CHUNGCHEONG_BUK", "CHUNGCHEONG_NAM", "JEOLLA_BUK", "JEOLLA_NAM",
                             "GYEONGSANG_BUK", "GYEONGSANG_NAM", "JEJU"}))
-            @RequestParam(value = "city", required = false) String city,
+            @Valid @EnumValid(enumClass = City.class) @RequestParam(value = "city", required = false) String city,
 
             @Parameter(name = "shelterName", description = "보호소 이름으로 검색합니다.", in = ParameterIn.QUERY)
             @RequestParam(value = "shelterName", required = false) String shelterName,
@@ -227,7 +230,7 @@ public class AdoptNoticeController {
 
             @Schema(allowableValues = {"ACCEPTING", "COMPLETE", "CANCELED"})
             @Parameter(name = "status", description = "수정하고자 하는 공고의 상태입니다.", in = ParameterIn.QUERY)
-            @RequestParam(name = "status") String status
+            @Valid @EnumValid(enumClass = AdoptNoticeStatus.class) @RequestParam(name = "status") String status
     ) {
         Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<AdoptNoticeResponseDto>builder()

--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
@@ -204,7 +204,7 @@ public class AdoptNoticeController {
 }
 """)})) @ApiResponseCommon @ApiResponseSignin
     @PreAuthorize("hasAnyRole('ROLE_USER')")
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PostMapping("")
     public CommonResponseDto<Map<String, Long>> createNoticeV1(@Valid @RequestBody final AdoptNoticeCreateRequestDto dto) {
         Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
@@ -219,7 +219,7 @@ public class AdoptNoticeController {
     @Operation(summary = "분양공고 상태 업데이트", description = "분양공고의 상태를 업데이트합니다.", operationId = "updateNoticeStatus")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @PreAuthorize("hasAnyRole('ROLE_USER')")
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PutMapping("/{noticeId}/status")
     public CommonResponseDto<AdoptNoticeResponseDto> updateNoticeStatusV1(
             @Parameter(name = "noticeId", description = "수정하고자 하는 공고의 id입니다.")
@@ -241,7 +241,7 @@ public class AdoptNoticeController {
     @Operation(summary = "분양공고 수정", description = "분양공고의 내용을 수정합니다.", operationId = "updateNotice")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @PreAuthorize("hasAnyRole('ROLE_USER')")
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PatchMapping("/{noticeId}")
     public CommonResponseDto<AdoptNoticeResponseDto> updateNoticeV1(
             @Parameter(name = "noticeId", description = "수정하고자 하는 공고의 id입니다.")
@@ -271,7 +271,7 @@ public class AdoptNoticeController {
 }
 """)})) @ApiResponseCommon @ApiResponseResource @ApiResponseAuthority
     @PreAuthorize("hasAnyRole('ROLE_USER')")
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @DeleteMapping("/{noticeId}")
     public CommonResponseDto<Map<String, Long>> deleteNoticeV1(
             @Parameter(name = "noticeId", description = "삭제하고자 하는 공고의 id입니다.")

--- a/MyohanMeeting/src/main/java/meet/myo/controller/FavoriteController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/FavoriteController.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 @Tag(name = "6. Favorite", description = "최애친구 관련 기능")
-@SecurityRequirement(name = "JWT")
+@SecurityRequirement(name = "Authorization")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/favorite")

--- a/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
@@ -155,7 +155,7 @@ public class MemberController {
     @Tag(name = "2. Member", description = "회원 관련 기능")
     @Operation(summary = "내 정보 보기", description = "자신의 회원정보를 확인합니다.", operationId = "getMyInfo")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     @GetMapping("")
     public CommonResponseDto<MemberResponseDto> getMyInfoV1() {
@@ -171,7 +171,7 @@ public class MemberController {
     @Tag(name = "2. Member", description = "회원 관련 기능")
     @Operation(summary = "내 정보 수정", description = "자신의 회원정보를 수정합니다.", operationId = "updateMyInfo")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     @PatchMapping("")
     public CommonResponseDto<MemberUpdateResponseDto> updateMyInfoV1(@RequestBody final MemberUpdateRequestDto dto) {
@@ -187,7 +187,7 @@ public class MemberController {
     @Tag(name = "2. Member", description = "회원 관련 기능")
     @Operation(summary = "이메일 수정", description = "이메일을 수정합니다.", operationId = "updateEmail")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     @PutMapping("/email")
     public CommonResponseDto<EmailUpdateResponseDto> updateEmailV1(@Valid @RequestBody final EmailUpdateRequestDto dto) {
@@ -205,7 +205,7 @@ public class MemberController {
             description = "로그인에 사용되는 비밀번호를 수정하거나, 비밀번호를 설정한 적 없는 SNS 회원의 경우 비밀번호를 새롭게 설정합니다.",
             operationId = "updatePassword")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     @PutMapping("/password")
     public CommonResponseDto updatePasswordV1(@RequestBody final PasswordUpdateRequestDto dto) {
@@ -222,7 +222,7 @@ public class MemberController {
             description = "로그인에 사용할 SNS를 새롭게 연결합니다. 이미 SNS 로그인 정보가 등록되어 있을 경우 먼저 해제가 필요합니다.",
             operationId = "registerOauth")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     @PostMapping("/oauthInfo")
     public CommonResponseDto<OauthRegisterResponseDto> registerOauthV1(@Valid @RequestBody final OauthRegisterRequestDto dto) {
@@ -238,7 +238,7 @@ public class MemberController {
     @Tag(name = "2. Member", description = "회원 관련 기능")
     @Operation(summary = "SNS 연결 해제", description = "연결된 SNS 로그인 정보를 해제합니다. 비밀번호를 등록한 회원만 해제가 가능합니다.", operationId = "removeOauth")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     @DeleteMapping("/oauthInfo")
     public CommonResponseDto removeOauthV1(@Valid @RequestBody OauthDeleteRequestDto dto) {
@@ -253,7 +253,7 @@ public class MemberController {
     @Tag(name = "2. Member", description = "회원 관련 기능")
     @Operation(summary = "회원 탈퇴", description = "서비스에서 탈퇴합니다.", operationId = "resign")
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
-    @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Authorization")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     @DeleteMapping("")
     public CommonResponseDto resignV1() {

--- a/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
@@ -140,12 +140,12 @@ public class MemberController {
     @SecurityRequirement(name = "")
     @PutMapping("/certification")
     public CommonResponseDto verifyCertificationEmailV1(
-            @Parameter(name = "email", description = "회원 가입한 이메일입니다.", in = ParameterIn.QUERY, example = "myemail@email.com")
-            @RequestParam(value = "email") @Valid @Email(message = "{validation.Email}") String email,
             @Parameter(name = "certCode", description = "메일로 전달된 인증 코드입니다.", in = ParameterIn.QUERY, example = "123456")
-            @RequestParam(value = "certCode") String certCode
+            @RequestParam(value = "certCode") String certCode,
+            @Parameter(name = "email", description = "회원 가입한 이메일입니다.", in = ParameterIn.QUERY, example = "myemail@email.com")
+            @RequestParam(value = "email") @Valid @Email(message = "{validation.Email}") String email
     ) {
-        memberService.verifyCertificationEmail(email, certCode);
+        memberService.verifyCertificationEmail(certCode, email);
         return CommonResponseDto.builder().build(); // TODO: 리턴값 어떻게 할지 생각
     }
 

--- a/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/MemberController.java
@@ -110,7 +110,7 @@ public class MemberController {
     @GetMapping("/nickname")
     public CommonResponseDto nicknameDuplicationCheckV1(
             @Parameter(name = "nickname", description = "중복을 확인할 닉네임입니다.", in = ParameterIn.QUERY)
-            @RequestParam(value = "nickname") @Valid @Size(min = 2, max = 12, message = "{validation.ValidJsonNullable}") String nickname
+            @RequestParam(value = "nickname") @Valid @Size(min = 2, max = 12, message = "{validation.Size}") String nickname
     ) {
         memberService.nicknameDuplicationCheck(nickname);
         return CommonResponseDto.builder().build();

--- a/MyohanMeeting/src/main/java/meet/myo/controller/UploadController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/UploadController.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 @Tag(name = "7. File", description = "파일 업로드 관련 기능")
-@SecurityRequirement(name = "JWT")
+@SecurityRequirement(name = "Authorization")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/files")

--- a/MyohanMeeting/src/main/java/meet/myo/controller/UploadController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/UploadController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import meet.myo.config.SecurityUtil;
+import meet.myo.domain.FileCategory;
 import meet.myo.dto.request.DeleteFilesRequestDto;
 import meet.myo.dto.response.CommonResponseDto;
 import meet.myo.dto.response.UploadResponseDto;
@@ -20,6 +21,7 @@ import meet.myo.springdoc.annotations.ApiResponseAuthority;
 import meet.myo.springdoc.annotations.ApiResponseCommon;
 import meet.myo.springdoc.annotations.ApiResponseResource;
 import meet.myo.springdoc.annotations.ApiResponseSignin;
+import meet.myo.util.validation.enums.EnumValid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -75,7 +77,7 @@ public class UploadController {
             @RequestParam(value = "files") MultipartFile[] files,
 
             @Schema(type = "string", allowableValues = {"CAT", "PROFILE", "SERVICE", "NO_CATEGORY"})
-            @RequestParam(value = "category") String fileCategory
+            @Valid @EnumValid(enumClass = FileCategory.class) @RequestParam(value = "category") String fileCategory
     ) {
         Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         return CommonResponseDto.<Map<String, List<Long>>>builder()

--- a/MyohanMeeting/src/main/java/meet/myo/domain/EmailCertification.java
+++ b/MyohanMeeting/src/main/java/meet/myo/domain/EmailCertification.java
@@ -24,6 +24,7 @@ public class EmailCertification extends BaseAuditingListener {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(nullable = false)
     private String email;
 
     @Column(nullable = false)

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/adopt/AdoptApplicationCreateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/adopt/AdoptApplicationCreateRequestDto.java
@@ -4,6 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import meet.myo.domain.adopt.application.Gender;
+import meet.myo.domain.adopt.application.Married;
+import meet.myo.domain.adopt.application.YesOrNo;
+import meet.myo.util.validation.enums.EnumValid;
 import meet.myo.util.validation.pattern.CustomPattern;
 import meet.myo.util.validation.pattern.CustomPatternRegexp;
 
@@ -41,6 +45,7 @@ public class AdoptApplicationCreateRequestDto {
 
         @Schema(type = "string", allowableValues = {"MALE", "FEMALE", "OTHER"}, example = "FEMALE")
         @NotNull(message = "{validation.NotNull}")
+        @EnumValid(enumClass = Gender.class)
         private String gender;
 
         @Schema(type = "string", example = "서울시 중구 필동 99가 9동 9호")
@@ -59,6 +64,7 @@ public class AdoptApplicationCreateRequestDto {
 
         @Schema(type = "string", allowableValues = {"MARRIED", "UNMARRIED"}, example = "UNMARRIED")
         @NotNull(message = "{validation.NotNull}")
+        @EnumValid(enumClass = Married.class)
         private String married;
 
     }
@@ -67,6 +73,7 @@ public class AdoptApplicationCreateRequestDto {
         @Schema(type = "string", allowableValues = {"YES", "NO"},
                 description = "1-1. 반려동물을 키우신 적이 있습니까?", example = "YES")
         @NotNull(message = "{validation.NotNull}")
+        @EnumValid(enumClass = YesOrNo.class)
         private String answer1_1;
 
         @Schema(type = "string", description = "1-2. 어떤 종류의 동물인지, 얼마나 키우셨는지, 지금은 어떻게 되었는지 적어주세요.",
@@ -77,6 +84,7 @@ public class AdoptApplicationCreateRequestDto {
         @Schema(type = "string", allowableValues = {"YES", "NO"},
                 description = "2-1. 현재 집에 다른 동물을 키우고 계십니까?", example = "YES")
         @NotNull(message = "{validation.NotNull}")
+        @EnumValid(enumClass = YesOrNo.class)
         private String answer2_1;
 
         @Schema(type = "string", description = "2-2. 동물의 종류와 나이, 성별, 중성화 여부를 적어주세요.",
@@ -93,6 +101,7 @@ public class AdoptApplicationCreateRequestDto {
         @Schema(type = "string", allowableValues = {"YES", "NO", "PARTIAL"},
                 description = "4. 가족들은 유기동물 입양을 찬성하나요?", example = "YES")
         @NotNull(message = "{validation.NotNull}")
+        @EnumValid(enumClass = YesOrNo.class)
         private String answer4;
 
         @Schema(type = "string", description = "5. 입양을 원하는 이유는 무엇인가요?",
@@ -104,6 +113,7 @@ public class AdoptApplicationCreateRequestDto {
         @Schema(type = "string", allowableValues = {"YES", "NO"},
                 description = "6. 만일 분양자가 원한다면 입양 후 입양동물의 사진을 전해주실 수 있나요?", example = "YES")
         @NotNull(message = "{validation.NotNull}")
+        @EnumValid(enumClass = YesOrNo.class)
         private String answer6;
     }
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/adopt/AdoptNoticeCreateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/adopt/AdoptNoticeCreateRequestDto.java
@@ -4,6 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import meet.myo.domain.adopt.notice.City;
+import meet.myo.domain.adopt.notice.cat.Neutered;
+import meet.myo.domain.adopt.notice.cat.Registered;
+import meet.myo.domain.adopt.notice.cat.Sex;
+import meet.myo.util.validation.enums.EnumValid;
 import meet.myo.util.validation.pattern.CustomPattern;
 import meet.myo.util.validation.pattern.CustomPatternRegexp;
 
@@ -55,12 +60,11 @@ public class AdoptNoticeCreateRequestDto {
                 allowableValues = {"REGISTERED", "NOT_REGISTERED"},
                 example = "REGISTERED")
         @NotNull(message = "{validation.NotNull}")
-        @Size(max = 32, message = "{validation.Size}")
+        @EnumValid(enumClass = Registered.class)
         private String registered;
 
         @Schema(type = "string", description = "농림축산검역본부 국가동물정보보호시스템에 등록된 구조동물 관리번호를 입력합니다.",
                 example = "전북-군산-2023-00000")
-        @NotNull(message = "{validation.NotNull}")
         @Size(max = 32, message = "{validation.Size}")
         private String registNumber;
 
@@ -75,10 +79,12 @@ public class AdoptNoticeCreateRequestDto {
 
         @Schema(type = "string", allowableValues = {"MALE", "FEMALE", "OTHER"}, example = "FEMALE")
         @NotNull(message = "{validation.NotNull}")
+        @EnumValid(enumClass = Sex.class)
         private String sex;
 
         @Schema(type = "string", allowableValues = {"NEUTERED", "NOT_NEUTERED", "UNKNOWN"}, example = "NEUTERED")
         @NotNull(message = "{validation.NotNull}")
+        @EnumValid(enumClass = Neutered.class)
         private String neutered;
 
         @Schema(type = "string", example = "건강에 아무 이상 없고 예방접종도 모두 마쳤어요.")
@@ -109,7 +115,7 @@ public class AdoptNoticeCreateRequestDto {
                 "ULSAN", "DAEJEON", "GYEONGGI", "GANGWON", "CHUNGCHEONG_BUK", "CHUNGCHEONG_NAM", "JEOLLA_BUK",
                 "JEOLLA_NAM", "GYEONGSANG_BUK", "GYEONGSANG_NAM", "JEJU"}, example = "JEOLLA_BUK")
         @NotNull(message = "{validation.NotNull}")
-        @Size(max = 255, message = "{validation.Size}")
+        @EnumValid(enumClass = City.class)
         private String city;
 
         @Schema(type = "string", example = "묘한보호소")

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/DirectSignInRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/DirectSignInRequestDto.java
@@ -17,7 +17,7 @@ public class DirectSignInRequestDto implements SignInRequestDto {
 
     @Schema(type = "string", example = "user1234!")
     @NotNull(message = "{validation.NotNull}")
-    @Size(min = 8, max = 24, message = "{validation.ValidJsonNullable}")
+    @Size(min = 8, max = 24, message = "{validation.Size}")
     @CustomPattern(regexp = CustomPatternRegexp.PASSWORD, message = "{validation.Pattern.password}")
     private String password;
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/OauthSignInRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/OauthSignInRequestDto.java
@@ -1,7 +1,6 @@
 package meet.myo.dto.request.auth;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import meet.myo.domain.OauthType;

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/TokenRefreshRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/auth/TokenRefreshRequestDto.java
@@ -1,7 +1,6 @@
 package meet.myo.dto.request.auth;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberDirectCreateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberDirectCreateRequestDto.java
@@ -16,12 +16,12 @@ public class MemberDirectCreateRequestDto {
 
     @Schema(type = "string", example = "user1234!")
     @NotNull(message="{validation.NotNull}")
-    @Size(min = 8, max = 24, message = "{validation.ValidJsonNullable}")
-    @CustomPattern(regexp = CustomPatternRegexp.PASSWORD, message = "{validation.password}")
+    @Size(min = 8, max = 24, message = "{validation.Size}")
+    @CustomPattern(regexp = CustomPatternRegexp.PASSWORD, message = "{validation.Pattern.password}")
     private String password;
 
     @NotNull(message = "{validation.NotNull}")
-    @Size(min = 2, max = 12, message = "{validation.ValidJsonNullable}")
+    @Size(min = 2, max = 12, message = "{validation.Size}")
     private String nickname;
 
     @NotNull(message = "{validation.NotNull}")

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberOauthCreateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/MemberOauthCreateRequestDto.java
@@ -25,7 +25,6 @@ public class MemberOauthCreateRequestDto {
     @Email(message = "{validation.Pattern.email}")
     private String email;
 
-//    @NotNull(message = "{validation.NotNull}")
-    @Size(min = 2, max = 12, message = "{validation.ValidJsonNullable}")
+    @Size(min = 2, max = 12, message = "{validation.Size}")
     private String nickname;
 }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/request/member/PasswordUpdateRequestDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/request/member/PasswordUpdateRequestDto.java
@@ -13,7 +13,7 @@ public class PasswordUpdateRequestDto {
     private String currentPassword;
 
     @Schema(type = "string", example = "newPassword")
-    @Size(min = 8, max = 24, message = "{validation.ValidJsonNullable}")
+    @Size(min = 8, max = 24, message = "{validation.Size}")
     @CustomPattern(regexp = CustomPatternRegexp.PASSWORD, message = "{validation.Pattern.password}")
     private String newPassword;
 }

--- a/MyohanMeeting/src/main/java/meet/myo/repository/EmailCertificationRepository.java
+++ b/MyohanMeeting/src/main/java/meet/myo/repository/EmailCertificationRepository.java
@@ -16,10 +16,10 @@ public interface EmailCertificationRepository extends JpaRepository<EmailCertifi
                                                        @Param("certCode") String certCode);
 
     @Query("select e from EmailCertification e " +
-            "where e.email = :email " +
-            "and e.certCode = :certCode " +
+            "where e.certCode = :certCode " +
+            "and e.email = :email " +
             "and e.deletedAt is NULL " +
             "order by e.id desc " +
             "limit 1")
-    Optional<EmailCertification> findByEmailAndCertCode(String email, String certCode);
+    Optional<EmailCertification> findByCertCodeAndEmail(String certCode, String email);
 }

--- a/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/MemberService.java
@@ -130,9 +130,10 @@ public class MemberService {
     /**
      * 이메일 인증 CertCode 비교
      */
-    public void verifyCertificationEmail(String email, String certCode) {
+    public void verifyCertificationEmail(String certCode, String email) {
+
         EmailCertification latestCertification =
-                emailCertificationRepository.findByEmailAndCertCode(email, certCode)
+                emailCertificationRepository.findByCertCodeAndEmail(certCode, email)
                 .orElseThrow(() -> new NotFoundException("인증 메일 정보를 찾을 수 없습니다."));
 
         Member member = latestCertification.getMember();

--- a/MyohanMeeting/src/main/java/meet/myo/util/validation/pattern/CustomPatternRegexp.java
+++ b/MyohanMeeting/src/main/java/meet/myo/util/validation/pattern/CustomPatternRegexp.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum CustomPatternRegexp {
-    PASSWORD("[a-z]+[0-9]+"),
+    PASSWORD("(?=.*\\d)(?=.*\\w).*"),
     PHONE_NUMBER("0(\\d){1,2}-(\\d){3,4}-(\\d){4}");
 
     private final String value;

--- a/MyohanMeeting/src/main/resources/import.sql
+++ b/MyohanMeeting/src/main/resources/import.sql
@@ -1,5 +1,5 @@
 -- 회원(운영자)
-insert into member (`created_at`, `email`, `password`, `nickname`, `phone_number`, `certified`) values (TIMESTAMP '2023-08-15 00:23:48.207129', 'admin@admin.com', '$2a$10$EI3YbKFob4MKhoJuE6y87.vu37kjdstBvK.YWNU1/U0rWcy1s0Slu', 'admin', '000-000-0000', 'CERTIFIED');
+insert into member (`created_at`, `email`, `password`, `nickname`, `phone_number`, `certified`) values (TIMESTAMP '2023-08-15 00:23:48.207129', 'admin@admin.com', '$2a$10$PQgvoDXZKkfKcfZ9le7/iuD/6WOA/RYmgyKjHfVcEefVFoknXqqoC', 'admin', '000-000-0000', 'CERTIFIED');
 
 -- 업로드
 -- 유저 프로필 이미지(관리자 회원이 업로드)
@@ -8,7 +8,7 @@ insert into upload (`created_at`, `extension`, `file_category`, `origin_name`, `
 update member set `profile_image_id` = 1 where `member_id` = 1;
 
 -- 회원(일반회원)
-insert into member (`created_at`, `email`, `password`, `nickname`, `phone_number`, `certified`, `profile_image_id`) values (TIMESTAMP '2023-08-15 00:23:48.207129', 'user@user.com', '$2a$10$E.2ZQcc2g2b29oORqmK.DeqeohuEvJiA6u5QH0N5n5EMCwqv2nSj.', 'user', '000-000-0000', 'CERTIFIED', 1);
+insert into member (`created_at`, `email`, `password`, `nickname`, `phone_number`, `certified`, `profile_image_id`) values (TIMESTAMP '2023-08-15 00:23:48.207129', 'user@user.com', '$2a$10$HL5JawgxCmMnTRJvaS9VE.cXDVo.ymm3dAntjcnpYe6G3WQy7RlZ.', 'user', '000-000-0000', 'CERTIFIED', 1);
 insert into member (`created_at`, `oauth_type`, `oauth_id`, `nickname`, `email`, `certified`, `profile_image_id`) values (TIMESTAMP '2023-08-15 00:23:48.207129', 'KAKAOTALK', '$2a$10$Dld5fafSWm2acfqohlRcBub6r9KVQ6K.wyuz7u3BY0P2RmIUFxADS', 'kakaouser', 'kakaotest@kakao.com', 'CERTIFIED', 1);
 
 -- 권한


### PR DESCRIPTION
### fix: Validation 오류 수정 
- 패스워드 정규식 오류 수정
- @ EnumValid 누락 추가
- 잘못된 @ Size 어노테이션 삭제
- message 오류 수정
- 불필요한 import 구문 삭제

### fix: 메일인증 오류 수정 
- email, certCode 순으로 쿼리를 생성하면 따옴표가 잘못 들어가는 오류가 있었음
- 원인은 찾지 못했으나 변수 순서 변경하여 해결
- 이후 혼동 없도록 컨트롤러, 서비스단의 메서드 인자 순서도 함께 변경함

### fix: swagger security 오류 수정 
- Security scheme 이름 오류 수정
- Swagger 로그인 정상 작동함

### fix: import.sql 수정 
- 비밀번호 데이터 재갱신