### PR TITLE
fix: 분양공고 목록 조회시 카운트 추가

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
+++ b/MyohanMeeting/src/main/java/meet/myo/controller/AdoptNoticeController.java
@@ -16,6 +16,7 @@ import meet.myo.domain.adopt.notice.AdoptNoticeStatus;
 import meet.myo.domain.adopt.notice.City;
 import meet.myo.dto.request.adopt.AdoptNoticeCreateRequestDto;
 import meet.myo.dto.request.adopt.AdoptNoticeUpdateRequestDto;
+import meet.myo.dto.response.adopt.AdoptNoticeListResponseDto;
 import meet.myo.dto.response.adopt.AdoptNoticeResponseDto;
 import meet.myo.dto.response.CommonResponseDto;
 import meet.myo.dto.response.adopt.AdoptNoticeSummaryResponseDto;
@@ -46,7 +47,7 @@ public class AdoptNoticeController {
     @Operation(summary = "분양공고 목록조회", description = "검색 조건에 따른 분양 공고 목록을 조회합니다.", operationId = "getNoticeList")
     @ApiResponse(responseCode = "200") @ApiResponseCommon
     @GetMapping("")
-    public CommonResponseDto<List<AdoptNoticeSummaryResponseDto>> getNoticeListV1(
+    public CommonResponseDto<AdoptNoticeListResponseDto> getNoticeListV1(
             /**
              * 페이징
              */
@@ -132,7 +133,7 @@ public class AdoptNoticeController {
                 .sort(sort)
                 .build();
 
-        return CommonResponseDto.<List<AdoptNoticeSummaryResponseDto>>builder()
+        return CommonResponseDto.<AdoptNoticeListResponseDto>builder()
                 .data(adoptNoticeService.getAdoptNoticeList(pageable, search))
                 .build();
     }
@@ -144,7 +145,7 @@ public class AdoptNoticeController {
     @ApiResponse(responseCode = "200") @ApiResponseCommon @ApiResponseSignin
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     @GetMapping("/my")
-    public CommonResponseDto<List<AdoptNoticeSummaryResponseDto>> getMyNoticeListV1(
+    public CommonResponseDto<AdoptNoticeListResponseDto> getMyNoticeListV1(
             /**
              * 페이징
              */
@@ -171,7 +172,7 @@ public class AdoptNoticeController {
     ) {
         Long memberId = SecurityUtil.getCurrentUserPK().orElseThrow(() -> new NotAuthenticatedException("INVALID_ID"));
         Pageable pageable = PageRequest.of(page, size);
-        return CommonResponseDto.<List<AdoptNoticeSummaryResponseDto>>builder()
+        return CommonResponseDto.<AdoptNoticeListResponseDto>builder()
                 .data(adoptNoticeService.getMyAdoptNoticeList(memberId, pageable, sort))
                 .build();
     }

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeListResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeListResponseDto.java
@@ -8,8 +8,12 @@ import java.util.List;
 @Schema(name = "AdoptNoticeList")
 @Getter
 public class AdoptNoticeListResponseDto {
+    @Schema(description = "현재 검색 조건에 해당하는 공고의 총 갯수입니다.")
     private Long totalRows;
+
+    @Schema(description = "현재 검색 조건에 해당하는 공고의 총 페이지 수입니다.")
     private Long totalPages;
+
     private List<AdoptNoticeSummaryResponseDto> adoptNoticeList;
 
     public static AdoptNoticeListResponseDto of(long totalRows, long totalPages, List<AdoptNoticeSummaryResponseDto> adoptNoticeList) {

--- a/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeListResponseDto.java
+++ b/MyohanMeeting/src/main/java/meet/myo/dto/response/adopt/AdoptNoticeListResponseDto.java
@@ -1,0 +1,23 @@
+package meet.myo.dto.response.adopt;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+
+@Schema(name = "AdoptNoticeList")
+@Getter
+public class AdoptNoticeListResponseDto {
+    private Long totalRows;
+    private Long totalPages;
+    private List<AdoptNoticeSummaryResponseDto> adoptNoticeList;
+
+    public static AdoptNoticeListResponseDto of(long totalRows, long totalPages, List<AdoptNoticeSummaryResponseDto> adoptNoticeList) {
+        AdoptNoticeListResponseDto dto = new AdoptNoticeListResponseDto();
+        dto.totalRows = totalRows;
+        dto.totalPages = totalPages;
+        dto.adoptNoticeList = adoptNoticeList;
+
+        return dto;
+    }
+}

--- a/MyohanMeeting/src/main/java/meet/myo/service/AdoptNoticeService.java
+++ b/MyohanMeeting/src/main/java/meet/myo/service/AdoptNoticeService.java
@@ -7,6 +7,7 @@ import meet.myo.domain.adopt.notice.*;
 import meet.myo.domain.adopt.notice.cat.*;
 import meet.myo.dto.request.adopt.*;
 import meet.myo.dto.response.adopt.AdoptNoticeCommentResponseDto;
+import meet.myo.dto.response.adopt.AdoptNoticeListResponseDto;
 import meet.myo.dto.response.adopt.AdoptNoticeResponseDto;
 import meet.myo.exception.NotFoundException;
 import meet.myo.dto.response.adopt.AdoptNoticeSummaryResponseDto;
@@ -14,6 +15,7 @@ import meet.myo.dto.response.adopt.AdoptNoticeSummaryResponseDto;
 import meet.myo.repository.*;
 import meet.myo.search.AdoptNoticeSearch;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -38,23 +40,33 @@ public class AdoptNoticeService {
      * 공고목록 전체 조회
      */
     @Transactional(readOnly = true)
-    public List<AdoptNoticeSummaryResponseDto> getAdoptNoticeList(Pageable pageable, AdoptNoticeSearch search) {
+    public AdoptNoticeListResponseDto getAdoptNoticeList(Pageable pageable, AdoptNoticeSearch search) {
+
         Page<AdoptNotice> adoptNotices = adoptNoticeRepo.findByDeletedAtNull(pageable, search);
-        return adoptNotices.getContent().stream()
+
+        return AdoptNoticeListResponseDto.of(
+                adoptNotices.getTotalElements(),
+                adoptNotices.getTotalPages(),
+                adoptNotices.getContent().stream()
                 .map(AdoptNoticeSummaryResponseDto::fromEntity)
-                .collect(Collectors.toList());
+                .collect(Collectors.toList())
+        );
     }
 
     /**
      * 특정 회원의 공고목록 전체 조회
      */
     @Transactional(readOnly = true)
-    public List<AdoptNoticeSummaryResponseDto> getMyAdoptNoticeList(Long memberId, Pageable pageable, String ordered) {
+    public AdoptNoticeListResponseDto getMyAdoptNoticeList(Long memberId, Pageable pageable, String ordered) {
 
         Page<AdoptNotice> adoptNotices = adoptNoticeRepository.findByMemberIdAndDeletedAtNull(pageable, memberId);
-        return adoptNotices.getContent().stream()
+        return AdoptNoticeListResponseDto.of(
+                adoptNotices.getTotalElements(),
+                adoptNotices.getTotalPages(),
+                adoptNotices.getContent().stream()
                 .map(AdoptNoticeSummaryResponseDto::fromEntity)
-                .collect(Collectors.toList());
+                .collect(Collectors.toList())
+        );
     }
 
     /**


### PR DESCRIPTION
- AdoptNotice 목록 조회 시 총 로우 갯수, 총 페이지수 포함해 응답
- 기존 AdoptNoticeSummary를 감싸는 Wrapper dto를 생성해 내부에 totalPages, totalRows, SummaryList 포함하도록 수정