### PR TITLE
fix: 개발환경 db 설정파일 분리

### DIFF
--- a/MyohanMeeting/src/main/resources/application-dev.yml
+++ b/MyohanMeeting/src/main/resources/application-dev.yml
@@ -1,10 +1,8 @@
 spring:
   config:
     import:
+      - classpath:dev-db-h2.yml
       - classpath:./config/secret-dev.yml
-
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:

--- a/MyohanMeeting/src/main/resources/dev-db-h2.yml
+++ b/MyohanMeeting/src/main/resources/dev-db-h2.yml
@@ -1,0 +1,12 @@
+
+h2:
+  console:
+    enabled: true
+    settings:
+      web-allow-others: true
+
+datasource:
+  url: jdbc:h2:mem:myomeet
+  driver-class-name: org.h2.Driver
+  username: sa
+  password:

--- a/MyohanMeeting/src/main/resources/dev-db-mysql.yml
+++ b/MyohanMeeting/src/main/resources/dev-db-mysql.yml
@@ -1,0 +1,3 @@
+
+datasource:
+  driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
- 프론트 요청으로 db를 h2로 롤백
- 관리 좀더 용이하게 하기 위해 설정파일 분리