### PR TITLE
hotfix: CORS 회피

### DIFF
--- a/MyohanMeeting/src/main/java/meet/myo/config/CorsCustomFilter.java
+++ b/MyohanMeeting/src/main/java/meet/myo/config/CorsCustomFilter.java
@@ -1,0 +1,46 @@
+package meet.myo.config;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CorsCustomFilter implements Filter {
+
+    @Override
+    public void doFilter(
+            ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain
+    ) throws IOException, ServletException {
+
+        HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
+        httpServletResponse.setHeader("Access-Control-Allow-Origin", "http://localhost:5173");
+        filterChain.doFilter(servletRequest, servletResponse);
+
+    }
+}
+//
+//@WebFilter("/filter-response-header/*")
+//public class AddResponseHeaderFilter implements Filter {
+//
+//    @Override
+//    public void doFilter(ServletRequest request, ServletResponse response,
+//                         FilterChain chain) throws IOException, ServletException {
+//        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+//        httpServletResponse.setHeader(
+//                "Baeldung-Example-Filter-Header", "Value-Filter");
+//        chain.doFilter(request, response);
+//    }
+//
+//    @Override
+//    public void init(FilterConfig filterConfig) throws ServletException {
+//        // ...
+//    }
+//
+//    @Override
+//    public void destroy() {
+//        // ...
+//    }
+//}
+//

--- a/MyohanMeeting/src/main/java/meet/myo/config/WebConfig.java
+++ b/MyohanMeeting/src/main/java/meet/myo/config/WebConfig.java
@@ -21,7 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins(serverUrl, clientUrl)
+                .allowedOrigins(serverUrl, clientUrl, "http://localhost:5173")
                 .allowedMethods("*")
                 .allowCredentials(true)
                 .maxAge(3000);

--- a/MyohanMeeting/src/main/resources/dev-db-h2.yml
+++ b/MyohanMeeting/src/main/resources/dev-db-h2.yml
@@ -1,12 +1,12 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
 
-h2:
-  console:
-    enabled: true
-    settings:
-      web-allow-others: true
-
-datasource:
-  url: jdbc:h2:mem:myomeet
-  driver-class-name: org.h2.Driver
-  username: sa
-  password:
+  datasource:
+    url: jdbc:h2:mem:myomeet
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:


### PR DESCRIPTION
- 프론트 로컬 cors 이슈로 임시로 허용 출처에 로컬호스트 추가
- 모든 요청에서 허용된 출처로 로컬호스트 응답하도록 강제로 필터 추가
